### PR TITLE
Read from config should not throw if MinimumLevel is not defined in settings file

### DIFF
--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -97,7 +97,7 @@ namespace Serilog.Settings.Configuration
         void ApplyMinimumLevel(LoggerConfiguration loggerConfiguration)
         {
             var minimumLevelDirective = _configuration.GetSection("MinimumLevel");
-            if (minimumLevelDirective != null)
+            if (minimumLevelDirective?.Value != null)
             {
                 LogEventLevel minimumLevel;
                 if (!Enum.TryParse(minimumLevelDirective.Value, out minimumLevel))


### PR DESCRIPTION
IConfiguration.GetSection(..) doesn't return null if section is not defined. With MinimumLevel we should check it's Value property.