### PR TITLE
Choose overloads based on matching parameter count

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -1,27 +1,49 @@
+echo "build: Build started"
+
 Push-Location $PSScriptRoot
 
-if(Test-Path .\artifacts) { Remove-Item .\artifacts -Force -Recurse }
+if(Test-Path .\artifacts) {
+	echo "build: Cleaning .\artifacts"
+	Remove-Item .\artifacts -Force -Recurse
+}
 
 & dotnet restore --no-cache
 
 $branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$env:APPVEYOR_REPO_BRANCH -ne $NULL];
 $revision = @{ $true = "{0:00000}" -f [convert]::ToInt32("0" + $env:APPVEYOR_BUILD_NUMBER, 10); $false = "local" }[$env:APPVEYOR_BUILD_NUMBER -ne $NULL];
-$suffix = @{ $true = ""; $false = "$branch-$revision"}[$branch -eq "master" -and $revision -ne "local"]
+$suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch.Length)))-$revision"}[$branch -eq "master" -and $revision -ne "local"]
 
-foreach ($src in ls src/Serilog.*) {
+echo "build: Version suffix is $suffix"
+
+foreach ($src in ls src/*) {
     Push-Location $src
 
-    & dotnet pack -c Release -o ..\..\.\artifacts --version-suffix=$suffix
+	echo "build: Packaging project in $src"
+
+    & dotnet pack -c Release -o ..\..\artifacts --version-suffix=$suffix
     if($LASTEXITCODE -ne 0) { exit 1 }    
 
     Pop-Location
 }
 
-foreach ($test in ls test/Serilog.*.Tests) {
+foreach ($test in ls test/*.PerformanceTests) {
     Push-Location $test
 
-    & dotnet test -c Release
+	echo "build: Building performance test project in $test"
+
+    & dotnet build -c Release
     if($LASTEXITCODE -ne 0) { exit 2 }
+
+    Pop-Location
+}
+
+foreach ($test in ls test/*.Tests) {
+    Push-Location $test
+
+	echo "build: Testing project in $test"
+
+    & dotnet test -c Release
+    if($LASTEXITCODE -ne 0) { exit 3 }
 
     Pop-Location
 }

--- a/sample/Sample/project.lock.json
+++ b/sample/Sample/project.lock.json
@@ -2349,13 +2349,12 @@
           "lib/netstandard1.3/_._": {}
         }
       },
-      "Serilog.Settings.Configuration/2.0.0-rc": {
+      "Serilog.Settings.Configuration/2.1.0": {
         "type": "project",
         "framework": ".NETStandard,Version=v1.6",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "1.0.0",
           "Microsoft.Extensions.DependencyModel": "1.0.0",
-          "Newtonsoft.Json": "9.0.1",
           "Serilog": "2.0.0"
         },
         "compile": {
@@ -2673,13 +2672,12 @@
           "lib/net45/_._": {}
         }
       },
-      "Serilog.Settings.Configuration/2.0.0-rc": {
+      "Serilog.Settings.Configuration/2.1.0": {
         "type": "project",
         "framework": ".NETFramework,Version=v4.5.1",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "1.0.0",
           "Microsoft.Extensions.DependencyModel": "1.0.0",
-          "Newtonsoft.Json": "9.0.1",
           "Serilog": "2.0.0",
           "System.Runtime": "4.0.10"
         },
@@ -7561,7 +7559,7 @@
         "ref/xamarinwatchos10/_._"
       ]
     },
-    "Serilog.Settings.Configuration/2.0.0-rc": {
+    "Serilog.Settings.Configuration/2.1.0": {
       "type": "project",
       "path": "../../src/Serilog.Settings.Configuration/project.json",
       "msbuildProject": "../../src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.xproj"

--- a/src/Serilog.Settings.Configuration/project.json
+++ b/src/Serilog.Settings.Configuration/project.json
@@ -9,7 +9,6 @@
     "iconUrl": "http://serilog.net/images/serilog-configuration-nuget.png"
   },
   "dependencies": {
-    "Newtonsoft.Json": "9.0.1",
     "Microsoft.Extensions.Configuration.Abstractions": "1.0.0",
     "Microsoft.Extensions.DependencyModel": "1.0.0",
     "Serilog": "2.0.0"

--- a/src/Serilog.Settings.Configuration/project.lock.json
+++ b/src/Serilog.Settings.Configuration/project.lock.json
@@ -3037,7 +3037,6 @@
     "": [
       "Microsoft.Extensions.Configuration.Abstractions >= 1.0.0",
       "Microsoft.Extensions.DependencyModel >= 1.0.0",
-      "Newtonsoft.Json >= 9.0.1",
       "Serilog >= 2.0.0"
     ],
     ".NETFramework,Version=v4.5.1": [

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
@@ -1,0 +1,49 @@
+﻿using System.Collections.Generic;
+using Serilog.Settings.Configuration;
+using Serilog.Formatting;
+using Serilog.Formatting.Json;
+using Xunit;
+using System.Reflection;
+using System.Linq;
+
+namespace Serilog.Settings.Configuration.Tests
+{
+    public class ConfigurationReaderTests
+    {
+        [Fact]
+        public void StringValuesConvertToDefaultInstancesIfTargetIsInterface()
+        {
+            var result = ConfigurationReader.ConvertToType("Serilog.Formatting.Json.JsonFormatter, Serilog", typeof(ITextFormatter));
+            Assert.IsType<JsonFormatter>(result);
+        }
+
+        [Fact]
+        public void CallableMethodsAreSelected()
+        {
+            var options = typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().DeclaredMethods.ToList();
+            Assert.Equal(2, options.Count(mi => mi.Name == "DummyRollingFile"));
+            var suppliedArguments = new Dictionary<string, string>
+            {
+                {"pathFormat", "C:\\" }
+            };
+
+            var selected = ConfigurationReader.SelectConfigurationMethod(options, "DummyRollingFile", suppliedArguments);
+            Assert.Equal(typeof(string), selected.GetParameters()[1].ParameterType);
+        }
+
+        [Fact]
+        public void MethodsAreSelectedBasedOnCountOfMatchedArguments()
+        {
+            var options = typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().DeclaredMethods.ToList();
+            Assert.Equal(2, options.Count(mi => mi.Name == "DummyRollingFile"));
+            var suppliedArguments = new Dictionary<string, string>()
+            {
+                { "pathFormat", "C:\\" },
+                { "formatter", "SomeFormatter, SomeAssembly" }
+            };
+
+            var selected = ConfigurationReader.SelectConfigurationMethod(options, "DummyRollingFile", suppliedArguments);
+            Assert.Equal(typeof(ITextFormatter), selected.GetParameters()[1].ParameterType);
+        }
+    }
+}

--- a/test/Serilog.Settings.Configuration.Tests/DummyLoggerConfigurationExtensions.cs
+++ b/test/Serilog.Settings.Configuration.Tests/DummyLoggerConfigurationExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Serilog.Configuration;
+using Serilog.Events;
+using Serilog.Formatting;
+
+namespace Serilog.Settings.Configuration.Tests
+{
+    static class DummyLoggerConfigurationExtensions
+    {
+        public static LoggerConfiguration DummyRollingFile(
+            LoggerSinkConfiguration loggerSinkConfiguration,
+            string pathFormat,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            string outputTemplate = null,
+            IFormatProvider formatProvider = null)
+        {
+            return null;
+        }
+
+        public static LoggerConfiguration DummyRollingFile(
+            LoggerSinkConfiguration loggerSinkConfiguration,
+            ITextFormatter formatter,
+            string pathFormat,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+        {
+            return null;
+        }
+    }
+}

--- a/test/Serilog.Settings.Configuration.Tests/project.json
+++ b/test/Serilog.Settings.Configuration.Tests/project.json
@@ -3,17 +3,13 @@
   "dependencies": {
     "Serilog.Settings.Configuration": { "target": "project" },
     "xunit": "2.1.0",
-    "dotnet-test-xunit": "1.0.0-rc3-build10026"
+    "dotnet-test-xunit": "1.0.0-rc2-build10025"
   },
   "buildOptions": {
     "keyFile": "../../assets/Serilog.snk"
   },
   "frameworks": {
-    "net4.6": {
-      "dependencies": {
-        "Microsoft.NETCore.Platforms": "1.0.1"
-      }
-    },
+    "net4.5.2": {},
     "netcoreapp1.0": {
       "dependencies": {
         "Microsoft.NETCore.App": {

--- a/test/Serilog.Settings.Configuration.Tests/project.lock.json
+++ b/test/Serilog.Settings.Configuration.Tests/project.lock.json
@@ -3,7 +3,7 @@
   "version": 2,
   "targets": {
     ".NETCoreApp,Version=v1.0": {
-      "dotnet-test-xunit/1.0.0-rc3-build10026": {
+      "dotnet-test-xunit/1.0.0-rc2-build10025": {
         "type": "package",
         "dependencies": {
           "Microsoft.Extensions.Testing.Abstractions": "1.0.0-preview1-002702",
@@ -2630,13 +2630,12 @@
           "lib/dotnet/xunit.runner.utility.dotnet.dll": {}
         }
       },
-      "Serilog.Settings.Configuration/2.0.0-rc": {
+      "Serilog.Settings.Configuration/2.1.0": {
         "type": "project",
         "framework": ".NETStandard,Version=v1.6",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "1.0.0",
           "Microsoft.Extensions.DependencyModel": "1.0.0",
-          "Newtonsoft.Json": "9.0.1",
           "Serilog": "2.0.0"
         },
         "compile": {
@@ -2647,8 +2646,8 @@
         }
       }
     },
-    ".NETFramework,Version=v4.6": {
-      "dotnet-test-xunit/1.0.0-rc3-build10026": {
+    ".NETFramework,Version=v4.5.2": {
+      "dotnet-test-xunit/1.0.0-rc2-build10025": {
         "type": "package",
         "dependencies": {
           "Microsoft.Extensions.Testing.Abstractions": "1.0.0-preview1-002702",
@@ -2796,14 +2795,14 @@
           "lib/net451/Microsoft.Extensions.Testing.Abstractions.dll": {}
         }
       },
-      "Microsoft.NETCore.Platforms/1.0.1": {
+      "Microsoft.NETCore.Platforms/1.0.1-rc2-24027": {
         "type": "package",
-        "compile": {
-          "lib/netstandard1.0/_._": {}
-        },
-        "runtime": {
-          "lib/netstandard1.0/_._": {}
+        "dependencies": {
+          "Microsoft.NETCore.Targets": "1.0.1-rc2-24027"
         }
+      },
+      "Microsoft.NETCore.Targets/1.0.1-rc2-24027": {
+        "type": "package"
       },
       "Newtonsoft.Json/9.0.1": {
         "type": "package",
@@ -3051,13 +3050,12 @@
           "lib/net35/xunit.runner.utility.desktop.dll": {}
         }
       },
-      "Serilog.Settings.Configuration/2.0.0-rc": {
+      "Serilog.Settings.Configuration/2.1.0": {
         "type": "project",
         "framework": ".NETFramework,Version=v4.5.1",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "1.0.0",
           "Microsoft.Extensions.DependencyModel": "1.0.0",
-          "Newtonsoft.Json": "9.0.1",
           "Serilog": "2.0.0",
           "System.Runtime": "4.0.10"
         },
@@ -3071,12 +3069,12 @@
     }
   },
   "libraries": {
-    "dotnet-test-xunit/1.0.0-rc3-build10026": {
-      "sha512": "/gFzS3wkG+QepAkPJ4Q3vOKULtBh1fHd2WV7Ed6IAuKevE1x2JorVkIyzAQI3lc6B6wwlXWhyXb6aWVoICFg+g==",
+    "dotnet-test-xunit/1.0.0-rc2-build10025": {
+      "sha512": "MhxfSjj6z/dpct/9zsssDAXKxWXhAx9s39080Qm+59k2vLJafUjUTzl4cs2rKHK7BYty2EyNxir68v7cJcaBEA==",
       "type": "package",
-      "path": "dotnet-test-xunit/1.0.0-rc3-build10026",
+      "path": "dotnet-test-xunit/1.0.0-rc2-build10025",
       "files": [
-        "dotnet-test-xunit.1.0.0-rc3-build10026.nupkg.sha512",
+        "dotnet-test-xunit.1.0.0-rc2-build10025.nupkg.sha512",
         "dotnet-test-xunit.nuspec",
         "lib/net451/dotnet-test-xunit.exe",
         "lib/netcoreapp1.0/dotnet-test-xunit.dll",
@@ -3375,6 +3373,18 @@
         "runtime.json"
       ]
     },
+    "Microsoft.NETCore.Platforms/1.0.1-rc2-24027": {
+      "sha512": "BIZpJMovdHgUbCrZR9suwwLpZMNehIkaFKiIb9X5+wPjXNHMSQ91ETSASAnEXERyU7+ptJAfJGqgr3Y9ly98MQ==",
+      "type": "package",
+      "path": "Microsoft.NETCore.Platforms/1.0.1-rc2-24027",
+      "files": [
+        "Microsoft.NETCore.Platforms.1.0.1-rc2-24027.nupkg.sha512",
+        "Microsoft.NETCore.Platforms.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "runtime.json"
+      ]
+    },
     "Microsoft.NETCore.Platforms/1.0.1": {
       "sha512": "2G6OjjJzwBfNOO8myRV/nFrbTw5iA+DEm0N+qUqhrOmaVtn4pC77h38I1jsXGw5VH55+dPfQsqHD0We9sCl9FQ==",
       "type": "package",
@@ -3395,6 +3405,18 @@
       "files": [
         "Microsoft.NETCore.Runtime.CoreCLR.1.0.2.nupkg.sha512",
         "Microsoft.NETCore.Runtime.CoreCLR.nuspec",
+        "ThirdPartyNotices.txt",
+        "dotnet_library_license.txt",
+        "runtime.json"
+      ]
+    },
+    "Microsoft.NETCore.Targets/1.0.1-rc2-24027": {
+      "sha512": "pNy4HhkgeM1kE/IqtDQLfUcMpy3NB3B/p8J/71G9Wvu2p/ARRH2hjq1TkETiqQW7ER9aFUs86wmgHyk3dtDgVQ==",
+      "type": "package",
+      "path": "Microsoft.NETCore.Targets/1.0.1-rc2-24027",
+      "files": [
+        "Microsoft.NETCore.Targets.1.0.1-rc2-24027.nupkg.sha512",
+        "Microsoft.NETCore.Targets.nuspec",
         "ThirdPartyNotices.txt",
         "dotnet_library_license.txt",
         "runtime.json"
@@ -8176,7 +8198,7 @@
         "xunit.runner.utility.nuspec"
       ]
     },
-    "Serilog.Settings.Configuration/2.0.0-rc": {
+    "Serilog.Settings.Configuration/2.1.0": {
       "type": "project",
       "path": "../../src/Serilog.Settings.Configuration/project.json",
       "msbuildProject": "../../src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.xproj"
@@ -8185,15 +8207,13 @@
   "projectFileDependencyGroups": {
     "": [
       "Serilog.Settings.Configuration",
-      "dotnet-test-xunit >= 1.0.0-rc3-build10026",
+      "dotnet-test-xunit >= 1.0.0-rc2-build10025",
       "xunit >= 2.1.0"
     ],
     ".NETCoreApp,Version=v1.0": [
       "Microsoft.NETCore.App >= 1.0.0"
     ],
-    ".NETFramework,Version=v4.6": [
-      "Microsoft.NETCore.Platforms >= 1.0.1"
-    ]
+    ".NETFramework,Version=v4.5.2": []
   },
   "tools": {},
   "projectFileToolGroups": {}


### PR DESCRIPTION
Not absolute parameter count. Corresponds to https://github.com/serilog/serilog/issues/798.

Also removes a spurious _Newtonsoft.Json_ dependency and fixes some test infrastructure issues in order to get it all building.