### PR TITLE
Filter support 

### DIFF
--- a/sample/Sample/Program.cs
+++ b/sample/Sample/Program.cs
@@ -5,6 +5,7 @@ using Serilog;
 using System.IO;
 
 using Serilog.Core;
+using Serilog.Events;
 
 namespace Sample
 {
@@ -30,6 +31,14 @@ namespace Sample
                 Console.WriteLine();
             }
             while (Console.ReadKey().KeyChar != 'q');
+        }
+    }
+
+    public class CustomFilter : ILogEventFilter
+    {
+        public bool IsEnabled(LogEvent logEvent)
+        {
+            return true;
         }
     }
 }

--- a/sample/Sample/appsettings.json
+++ b/sample/Sample/appsettings.json
@@ -26,6 +26,20 @@
     "Enrich": ["FromLogContext", "WithMachineName", "WithThreadId"],
     "Properties": {
       "Application": "Sample"
-    }
+    },
+    "Filter": [
+      {
+        "Name": "ByIncludingOnly",
+        "Args": {
+          "expression": "Application = 'Sample'"
+        }
+      },
+      {
+        "Name": "With",
+        "Args": {
+          "filter": "Sample.CustomFilter, Sample"
+        }
+      }
+    ]
   }
 }

--- a/sample/Sample/project.json
+++ b/sample/Sample/project.json
@@ -9,7 +9,8 @@
     "Serilog.Sinks.Literate": "2.0.0",
     "Serilog.Sinks.RollingFile":  "3.0.0",
     "Serilog.Enrichers.Environment": "2.0.0",
-    "Serilog.Enrichers.Thread":  "2.0.0"
+    "Serilog.Enrichers.Thread": "2.0.0",
+    "Serilog.Filters.Expressions": "1.0.0-*"
   },
   "frameworks": {
     "net4.6": {


### PR DESCRIPTION
- fixes [#32](https://github.com/serilog/serilog-settings-configuration/issues/32)
- some cleanup/unification around surrogate configuration methods

With the help of the greatest `Serilog.Filters.Expressions` will support these kinds of configurations:
```json
"Filter": [
      {
        "Name": "ByIncludingOnly",
        "Args": {
          "expression": "Application = 'Sample'"
        }
      },
      {
        "Name": "With",
        "Args": {
          "filter": "Sample.CustomFilter, Sample"
        }
      }
 ],
```
