### PR TITLE
Configure sub-loggers through JSON appsettings

### DIFF
--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -14,7 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="1.0.1" />
     <PackageReference Include="Serilog.Sinks.Literate" Version="2.0.0" />
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.0.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.0.0" />

--- a/sample/Sample/appsettings.json
+++ b/sample/Sample/appsettings.json
@@ -10,18 +10,35 @@
     },
     "WriteTo": [
       {
-        "Name": "LiterateConsole",
+        "Name": "Logger",
         "Args": {
-          "outputTemplate": "[{Timestamp:HH:mm:ss} {SourceContext} [{Level}] {Message}{NewLine}{Exception}"
-        } 
-      },
-      {        
-        "Name": "File",
-        "Args": {
-          "path": "%TEMP%\\Logs\\serilog-configuration-sample.txt",
-          "outputTemplate": "{Timestamp:o} [{Level:u3}] ({Application}/{MachineName}/{ThreadId}) {Message}{NewLine}{Exception}"
+          "configureLogger": {
+            "WriteTo": [
+              {
+                "Name": "LiterateConsole",
+                "Args": {
+                  "outputTemplate": "[{Timestamp:HH:mm:ss} {SourceContext} [{Level}] {Message}{NewLine}{Exception}"
+                }
+              }
+            ]
+          },
+          "restrictedToMinimumLevel": "Debug"
         }
-      }
+      },
+      {
+        "Name": "Async",
+        "Args": {
+          "configure": [
+            {
+              "Name": "File",
+              "Args": {
+                "path": "%TEMP%\\Logs\\serilog-configuration-sample.txt",
+                "outputTemplate": "{Timestamp:o} [{Level:u3}] ({Application}/{MachineName}/{ThreadId}) {Message}{NewLine}{Exception}"
+              }
+            }
+          ]
+        }
+      }      
     ],
     "Enrich": ["FromLogContext", "WithMachineName", "WithThreadId"],
     "Properties": {

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -15,58 +15,102 @@ using System.Linq.Expressions;
 
 namespace Serilog.Settings.Configuration
 {
-    class ConfigurationReader : ILoggerSettings
+    class ConfigurationReader : IConfigurationReader
     {
         readonly IConfigurationSection _configuration;
         readonly DependencyContext _dependencyContext;
+        readonly Assembly[] _configurationAssemblies;
 
         public ConfigurationReader(IConfigurationSection configuration, DependencyContext dependencyContext)
         {
-            if (configuration == null) throw new ArgumentNullException(nameof(configuration));
-
-            _configuration = configuration;
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
             _dependencyContext = dependencyContext;
+            _configurationAssemblies = LoadConfigurationAssemblies();
+        }
+
+        ConfigurationReader(IConfigurationSection configuration, Assembly[] configurationAssemblies, DependencyContext dependencyContext)
+        {
+            _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+            _dependencyContext = dependencyContext;
+            _configurationAssemblies = configurationAssemblies ?? throw new ArgumentNullException(nameof(configurationAssemblies));
         }
 
         public void Configure(LoggerConfiguration loggerConfiguration)
         {
-            var configurationAssemblies = LoadConfigurationAssemblies();
-
             ApplyMinimumLevel(loggerConfiguration);
-            ApplyEnrichment(loggerConfiguration, configurationAssemblies);
-            ApplyFilters(loggerConfiguration, configurationAssemblies);
-            ApplySinks(loggerConfiguration, configurationAssemblies);
+            ApplyEnrichment(loggerConfiguration);
+            ApplyFilters(loggerConfiguration);
+            ApplySinks(loggerConfiguration);
+        }        
+
+        void ApplyMinimumLevel(LoggerConfiguration loggerConfiguration)
+        {
+            var minimumLevelDirective = _configuration.GetSection("MinimumLevel");
+
+            var defaultMinLevelDirective = minimumLevelDirective.Value != null ? minimumLevelDirective : minimumLevelDirective.GetSection("Default");
+            if (defaultMinLevelDirective.Value != null)
+            {
+                ApplyMinimumLevel(defaultMinLevelDirective, (configuration, levelSwitch) => configuration.ControlledBy(levelSwitch));
+            }
+
+            foreach (var overrideDirective in minimumLevelDirective.GetSection("Override").GetChildren())
+            {
+                ApplyMinimumLevel(overrideDirective, (configuration, levelSwitch) => configuration.Override(overrideDirective.Key, levelSwitch));
+            }
+
+            void ApplyMinimumLevel(IConfigurationSection directive, Action<LoggerMinimumLevelConfiguration, LoggingLevelSwitch> applyConfigAction)
+            {
+                if (!Enum.TryParse(directive.Value, out LogEventLevel minimumLevel))
+                    throw new InvalidOperationException($"The value {directive.Value} is not a valid Serilog level.");
+
+                var levelSwitch = new LoggingLevelSwitch(minimumLevel);
+                applyConfigAction(loggerConfiguration.MinimumLevel, levelSwitch);
+
+                ChangeToken.OnChange(
+                    directive.GetReloadToken,
+                    () =>
+                    {
+                        if (Enum.TryParse(directive.Value, out minimumLevel))
+                            levelSwitch.MinimumLevel = minimumLevel;
+                        else
+                            SelfLog.WriteLine($"The value {directive.Value} is not a valid Serilog level.");
+                    });
+            }
         }
 
-        void ApplyFilters(LoggerConfiguration loggerConfiguration, Assembly[] configurationAssemblies)
+        void ApplyFilters(LoggerConfiguration loggerConfiguration)
         {
             var filterDirective = _configuration.GetSection("Filter");
             if (filterDirective != null)
             {
                 var methodCalls = GetMethodCalls(filterDirective);
-                CallConfigurationMethods(methodCalls, FindFilterConfigurationMethods(configurationAssemblies), loggerConfiguration.Filter);
+                CallConfigurationMethods(methodCalls, FindFilterConfigurationMethods(_configurationAssemblies), loggerConfiguration.Filter);
             }
         }
 
-        void ApplySinks(LoggerConfiguration loggerConfiguration, Assembly[] configurationAssemblies)
+        void ApplySinks(LoggerConfiguration loggerConfiguration)
         {
             var writeToDirective = _configuration.GetSection("WriteTo");
             if (writeToDirective != null)
             {
                 var methodCalls = GetMethodCalls(writeToDirective);
-                CallConfigurationMethods(methodCalls, FindSinkConfigurationMethods(configurationAssemblies),
-                    loggerConfiguration.WriteTo);
+                CallConfigurationMethods(methodCalls, FindSinkConfigurationMethods(_configurationAssemblies), loggerConfiguration.WriteTo);
             }
         }
 
-        void ApplyEnrichment(LoggerConfiguration loggerConfiguration, Assembly[] configurationAssemblies)
+        void IConfigurationReader.ApplySinks(LoggerSinkConfiguration loggerSinkConfiguration)
+        {
+            var methodCalls = GetMethodCalls(_configuration);
+            CallConfigurationMethods(methodCalls, FindSinkConfigurationMethods(_configurationAssemblies), loggerSinkConfiguration);
+        }
+
+        void ApplyEnrichment(LoggerConfiguration loggerConfiguration)
         {
             var enrichDirective = _configuration.GetSection("Enrich");
             if (enrichDirective != null)
             {
                 var methodCalls = GetMethodCalls(enrichDirective);
-                CallConfigurationMethods(methodCalls, FindEventEnricherConfigurationMethods(configurationAssemblies),
-                    loggerConfiguration.Enrich);
+                CallConfigurationMethods(methodCalls, FindEventEnricherConfigurationMethods(_configurationAssemblies), loggerConfiguration.Enrich);
             }
 
             var propertiesDirective = _configuration.GetSection("Properties");
@@ -79,15 +123,15 @@ namespace Serilog.Settings.Configuration
             }
         }
 
-        Dictionary<string, Dictionary<string, string>> GetMethodCalls(IConfigurationSection directive)
+        Dictionary<string, Dictionary<string, IConfigurationArgumentValue>> GetMethodCalls(IConfigurationSection directive)
         {
-            var result = new Dictionary<string, Dictionary<string, string>>();
+            var result = new Dictionary<string, Dictionary<string, IConfigurationArgumentValue>>();
             foreach (var child in directive.GetChildren())
             {
                 if (child.Value != null)
                 {
                     // Plain string
-                    result.Add(child.Value, new Dictionary<string, string>());
+                    result.Add(child.Value, new Dictionary<string, IConfigurationArgumentValue>());
                 }
                 else
                 {
@@ -95,58 +139,30 @@ namespace Serilog.Settings.Configuration
                     if (name.Value == null)
                         throw new InvalidOperationException($"The configuration value in {name.Path} has no Name element.");
 
-                    var callArgs = new Dictionary<string, string>();
+                    var callArgs = new Dictionary<string, IConfigurationArgumentValue>();
                     var args = child.GetSection("Args");
                     if (args != null)
                     {
                         foreach (var argument in args.GetChildren())
                         {
-                            callArgs.Add(argument.Key, Environment.ExpandEnvironmentVariables(argument.Value));
+                            IConfigurationArgumentValue argumentValue;
+                            if (argument.Value != null)
+                            {
+                                argumentValue = new StringArgumentValue(() => argument.Value, argument.GetReloadToken);
+                            }
+                            else
+                            {
+                                argumentValue = new ConfigurationSectionArgumentValue(new ConfigurationReader(argument, _configurationAssemblies, _dependencyContext));
+                            }
+
+                            callArgs.Add(argument.Key, argumentValue);
                         }
                     }
                     result.Add(name.Value, callArgs);
                 }
             }
             return result;
-        }
-
-        void ApplyMinimumLevel(LoggerConfiguration loggerConfiguration)
-        {
-            var applyMinimumLevelAction =
-                new Action<IConfigurationSection, Action<LoggerMinimumLevelConfiguration, LoggingLevelSwitch>>(
-                    (directive, applyConfigAction) =>
-                    {
-                        LogEventLevel minimumLevel;
-                        if (!Enum.TryParse(directive.Value, out minimumLevel))
-                            throw new InvalidOperationException($"The value {directive.Value} is not a valid Serilog level.");
-
-                        var levelSwitch = new LoggingLevelSwitch(minimumLevel);
-                        applyConfigAction(loggerConfiguration.MinimumLevel, levelSwitch);
-
-                        ChangeToken.OnChange(
-                            directive.GetReloadToken,
-                            () =>
-                            {
-                                if (Enum.TryParse(directive.Value, out minimumLevel))
-                                    levelSwitch.MinimumLevel = minimumLevel;
-                                else
-                                    SelfLog.WriteLine($"The value {directive.Value} is not a valid Serilog level.");
-                            });
-                    });
-
-            var minimumLevelDirective = _configuration.GetSection("MinimumLevel");
-
-            var defaultMinLevelDirective = minimumLevelDirective.Value != null ? minimumLevelDirective : minimumLevelDirective.GetSection("Default");
-            if (defaultMinLevelDirective.Value != null)
-            {
-                applyMinimumLevelAction(defaultMinLevelDirective, (configuration, levelSwitch) => configuration.ControlledBy(levelSwitch));
-            }
-
-            foreach (var overrideDirective in minimumLevelDirective.GetSection("Override").GetChildren())
-            {
-                applyMinimumLevelAction(overrideDirective, (configuration, levelSwitch) => configuration.Override(overrideDirective.Key, levelSwitch));
-            }
-        }
+        }        
 
         Assembly[] LoadConfigurationAssemblies()
         {
@@ -201,7 +217,7 @@ namespace Serilog.Settings.Configuration
             return query.ToArray();
         }
 
-        static void CallConfigurationMethods(Dictionary<string, Dictionary<string, string>> methods, IList<MethodInfo> configurationMethods, object receiver)
+        static void CallConfigurationMethods(Dictionary<string, Dictionary<string, IConfigurationArgumentValue>> methods, IList<MethodInfo> configurationMethods, object receiver)
         {
             foreach (var method in methods)
             {
@@ -211,7 +227,7 @@ namespace Serilog.Settings.Configuration
                 {
                     var call = (from p in methodInfo.GetParameters().Skip(1)
                                 let directive = method.Value.FirstOrDefault(s => s.Key == p.Name)
-                                select directive.Key == null ? p.DefaultValue : ConvertToType(directive.Value, p.ParameterType)).ToList();
+                                select directive.Key == null ? p.DefaultValue : directive.Value.ConvertTo(p.ParameterType)).ToList();
 
                     call.Insert(0, receiver);
 
@@ -220,7 +236,7 @@ namespace Serilog.Settings.Configuration
             }
         }
 
-        internal static MethodInfo SelectConfigurationMethod(IEnumerable<MethodInfo> candidateMethods, string name, Dictionary<string, string> suppliedArgumentValues)
+        internal static MethodInfo SelectConfigurationMethod(IEnumerable<MethodInfo> candidateMethods, string name, Dictionary<string, IConfigurationArgumentValue> suppliedArgumentValues)
         {
             return candidateMethods
                 .Where(m => m.Name == name &&
@@ -229,69 +245,20 @@ namespace Serilog.Settings.Configuration
                 .FirstOrDefault();
         }
 
-        static readonly Dictionary<Type, Func<string, object>> ExtendedTypeConversions = new Dictionary<Type, Func<string, object>>
-            {
-                { typeof(Uri), s => new Uri(s) },
-                { typeof(TimeSpan), s => TimeSpan.Parse(s) }
-            };
-
-
-        internal static object ConvertToType(string value, Type toType)
-        {
-            var toTypeInfo = toType.GetTypeInfo();
-            if (toTypeInfo.IsGenericType && toType.GetGenericTypeDefinition() == typeof(Nullable<>))
-            {
-                if (string.IsNullOrEmpty(value))
-                    return null;
-
-                // unwrap Nullable<> type since we're not handling null situations
-                toType = toTypeInfo.GenericTypeArguments[0];
-                toTypeInfo = toType.GetTypeInfo();
-            }
-
-            if (toTypeInfo.IsEnum)
-                return Enum.Parse(toType, value);
-
-            var convertor = ExtendedTypeConversions
-                .Where(t => t.Key.GetTypeInfo().IsAssignableFrom(toTypeInfo))
-                .Select(t => t.Value)
-                .FirstOrDefault();
-
-            if (convertor != null)
-                 return convertor(value);
- 
-            if (toTypeInfo.IsInterface && !string.IsNullOrWhiteSpace(value))
-            {
-                var type = Type.GetType(value.Trim(), throwOnError: false);
-                if (type != null)
-                {
-                    var ctor = type.GetTypeInfo().DeclaredConstructors.FirstOrDefault(ci =>
-                    {
-                        var parameters = ci.GetParameters();
-                        return parameters.Length == 0 || parameters.All(pi => pi.HasDefaultValue);
-                    });
- 
-                    if (ctor == null)
-                        throw new InvalidOperationException($"A default constructor was not found on {type.FullName}.");
- 
-                    var call = ctor.GetParameters().Select(pi => pi.DefaultValue).ToArray();
-                    return ctor.Invoke(call);
-                }
-            }
-
-            return Convert.ChangeType(value, toType);
-        }
-
         internal static IList<MethodInfo> FindSinkConfigurationMethods(IEnumerable<Assembly> configurationAssemblies)
         {
-            return FindConfigurationMethods(configurationAssemblies, typeof(LoggerSinkConfiguration));
+            var found = FindConfigurationMethods(configurationAssemblies, typeof(LoggerSinkConfiguration));
+            if (configurationAssemblies.Contains(typeof(LoggerSinkConfiguration).GetTypeInfo().Assembly))
+                found.Add(GetSurrogateConfigurationMethod<LoggerSinkConfiguration, Action<LoggerConfiguration>, LoggingLevelSwitch>((c, a, s) => Logger(c, a, s)));
+
+            return found;
         }
 
         internal static IList<MethodInfo> FindFilterConfigurationMethods(IEnumerable<Assembly> configurationAssemblies)
         {
             var found = FindConfigurationMethods(configurationAssemblies, typeof(LoggerFilterConfiguration));
             if (configurationAssemblies.Contains(typeof(LoggerFilterConfiguration).GetTypeInfo().Assembly))
-                found.Add(GetSurrogateConfigurationMethod<LoggerFilterConfiguration, ILogEventFilter>((c, f) => With(c, f)));
+                found.Add(GetSurrogateConfigurationMethod<LoggerFilterConfiguration, ILogEventFilter, object>((c, f, _) => With(c, f)));
 
             return found;
         }
@@ -300,7 +267,7 @@ namespace Serilog.Settings.Configuration
         {
             var found = FindConfigurationMethods(configurationAssemblies, typeof(LoggerEnrichmentConfiguration));
             if (configurationAssemblies.Contains(typeof(LoggerEnrichmentConfiguration).GetTypeInfo().Assembly))
-                found.Add(GetSurrogateConfigurationMethod<LoggerEnrichmentConfiguration, object>((c, _) => FromLogContext(c)));
+                found.Add(GetSurrogateConfigurationMethod<LoggerEnrichmentConfiguration, object, object>((c, _, __) => FromLogContext(c)));
 
             return found;
         }
@@ -319,19 +286,17 @@ namespace Serilog.Settings.Configuration
 
         // don't support (yet?) arrays in the parameter list (ILogEventEnricher[])
         internal static LoggerConfiguration With(LoggerFilterConfiguration loggerFilterConfiguration, ILogEventFilter filter)
-        {
-            return loggerFilterConfiguration.With(filter);
-        }
+            => loggerFilterConfiguration.With(filter);
 
         // Unlike the other configuration methods, FromLogContext is an instance method rather than an extension.
         internal static LoggerConfiguration FromLogContext(LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
-        {
-            return loggerEnrichmentConfiguration.FromLogContext();
-        }
+            => loggerEnrichmentConfiguration.FromLogContext();
 
-        internal static MethodInfo GetSurrogateConfigurationMethod<TConfiguration, TArg>(Expression<Action<TConfiguration, TArg>> method)
-        {
-            return (method.Body as MethodCallExpression)?.Method;
-        }
+        // Unlike the other configuration methods, Logger is an instance method rather than an extension.
+        internal static LoggerConfiguration Logger(LoggerSinkConfiguration loggerSinkConfiguration, Action<LoggerConfiguration> configureLogger, LoggingLevelSwitch restrictedToMinimumLevel = null)
+            => loggerSinkConfiguration.Logger(configureLogger, levelSwitch: restrictedToMinimumLevel);
+
+        internal static MethodInfo GetSurrogateConfigurationMethod<TConfiguration, TArg1, TArg2>(Expression<Action<TConfiguration, TArg1, TArg2>> method)
+            => (method.Body as MethodCallExpression)?.Method;
     }
 }

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationSectionArgumentValue.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationSectionArgumentValue.cs
@@ -33,7 +33,7 @@ namespace Serilog.Settings.Configuration
                 return new Action<LoggerConfiguration>(_configReader.Configure);
             }
 
-            throw new Exception($"Handling {configurationType} is not implemented.");
+            throw new ArgumentException($"Handling {configurationType} is not implemented.");
         }
     }
 }

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationSectionArgumentValue.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationSectionArgumentValue.cs
@@ -1,0 +1,39 @@
+﻿using Serilog.Configuration;
+using System;
+using System.Reflection;
+
+namespace Serilog.Settings.Configuration
+{
+    class ConfigurationSectionArgumentValue : IConfigurationArgumentValue
+    {
+        readonly IConfigurationReader _configReader;
+
+        public ConfigurationSectionArgumentValue(IConfigurationReader configReader)
+        {
+            _configReader = configReader ?? throw new ArgumentNullException(nameof(configReader));
+        }
+
+        public object ConvertTo(Type toType)
+        {
+            var typeInfo = toType.GetTypeInfo();
+            if (!typeInfo.IsGenericType || 
+                 typeInfo.GetGenericTypeDefinition() is Type genericType && genericType != typeof(Action<>))
+            {
+                throw new InvalidOperationException("Argument value should be of type Action<>.");
+            }
+
+            var configurationType = typeInfo.GenericTypeArguments[0];
+            if (configurationType == typeof(LoggerSinkConfiguration))
+            {
+                return new Action<LoggerSinkConfiguration>(_configReader.ApplySinks);
+            }
+
+            if (configurationType == typeof(LoggerConfiguration))
+            {
+                return new Action<LoggerConfiguration>(_configReader.Configure);
+            }
+
+            throw new Exception($"Handling {configurationType} is not implemented.");
+        }
+    }
+}

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/IConfigurationArgumentValue.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/IConfigurationArgumentValue.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Serilog.Settings.Configuration
+{
+    interface IConfigurationArgumentValue
+    {
+        object ConvertTo(Type toType);
+    }
+}

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/IConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/IConfigurationReader.cs
@@ -1,0 +1,9 @@
+﻿using Serilog.Configuration;
+
+namespace Serilog.Settings.Configuration
+{
+    interface IConfigurationReader : ILoggerSettings
+    {
+        void ApplySinks(LoggerSinkConfiguration loggerSinkConfiguration);
+    }
+}

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/StringArgumentValue.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/StringArgumentValue.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+using Microsoft.Extensions.Primitives;
+
+using Serilog.Core;
+using Serilog.Debugging;
+using Serilog.Events;
+
+namespace Serilog.Settings.Configuration
+{
+    class StringArgumentValue : IConfigurationArgumentValue
+    {
+        readonly Func<string> _valueProducer;
+        readonly Func<IChangeToken> _changeTokenProducer;
+
+        public StringArgumentValue(Func<string> valueProducer, Func<IChangeToken> changeTokenProducer = null)
+        {
+            _valueProducer = valueProducer ?? throw new ArgumentNullException(nameof(valueProducer));
+            _changeTokenProducer = changeTokenProducer;
+        }
+
+        static readonly Dictionary<Type, Func<string, object>> ExtendedTypeConversions = new Dictionary<Type, Func<string, object>>
+            {
+                { typeof(Uri), s => new Uri(s) },
+                { typeof(TimeSpan), s => TimeSpan.Parse(s) }
+            };
+
+        public object ConvertTo(Type toType)
+        {
+            var argumentValue = Environment.ExpandEnvironmentVariables(_valueProducer());
+
+            var toTypeInfo = toType.GetTypeInfo();
+            if (toTypeInfo.IsGenericType && toType.GetGenericTypeDefinition() == typeof(Nullable<>))
+            {
+                if (string.IsNullOrEmpty(argumentValue))
+                    return null;
+
+                // unwrap Nullable<> type since we're not handling null situations
+                toType = toTypeInfo.GenericTypeArguments[0];
+                toTypeInfo = toType.GetTypeInfo();
+            }
+
+            if (toTypeInfo.IsEnum)
+                return Enum.Parse(toType, argumentValue);
+
+            var convertor = ExtendedTypeConversions
+                .Where(t => t.Key.GetTypeInfo().IsAssignableFrom(toTypeInfo))
+                .Select(t => t.Value)
+                .FirstOrDefault();
+
+            if (convertor != null)
+                return convertor(argumentValue);
+
+            if (toTypeInfo.IsInterface && !string.IsNullOrWhiteSpace(argumentValue))
+            {
+                var type = Type.GetType(argumentValue.Trim(), throwOnError: false);
+                if (type != null)
+                {
+                    var ctor = type.GetTypeInfo().DeclaredConstructors.FirstOrDefault(ci =>
+                    {
+                        var parameters = ci.GetParameters();
+                        return parameters.Length == 0 || parameters.All(pi => pi.HasDefaultValue);
+                    });
+
+                    if (ctor == null)
+                        throw new InvalidOperationException($"A default constructor was not found on {type.FullName}.");
+
+                    var call = ctor.GetParameters().Select(pi => pi.DefaultValue).ToArray();
+                    return ctor.Invoke(call);
+                }
+            }
+
+            if (toType == typeof(LoggingLevelSwitch))
+            {
+                if (!Enum.TryParse(argumentValue, out LogEventLevel minimumLevel))
+                    throw new InvalidOperationException($"The value `{argumentValue}` is not a valid Serilog level.");
+
+                var levelSwitch = new LoggingLevelSwitch(minimumLevel);
+
+                if (_changeTokenProducer != null)
+                {
+                    ChangeToken.OnChange(
+                        _changeTokenProducer,
+                        () =>
+                        {
+                            var newArgumentValue = _valueProducer();
+
+                            if (Enum.TryParse(newArgumentValue, out minimumLevel))
+                                levelSwitch.MinimumLevel = minimumLevel;
+                            else
+                                SelfLog.WriteLine($"The value `{newArgumentValue}` is not a valid Serilog level.");
+                        });
+                }
+
+                return levelSwitch;
+            }
+
+            return Convert.ChangeType(argumentValue, toType);
+        }
+    }
+}

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections.Generic;
-using Serilog.Settings.Configuration;
 using Serilog.Formatting;
-using Serilog.Formatting.Json;
 using Xunit;
 using System.Reflection;
 using System.Linq;
@@ -11,20 +9,13 @@ namespace Serilog.Settings.Configuration.Tests
     public class ConfigurationReaderTests
     {
         [Fact]
-        public void StringValuesConvertToDefaultInstancesIfTargetIsInterface()
-        {
-            var result = ConfigurationReader.ConvertToType("Serilog.Formatting.Json.JsonFormatter, Serilog", typeof(ITextFormatter));
-            Assert.IsType<JsonFormatter>(result);
-        }
-
-        [Fact]
         public void CallableMethodsAreSelected()
         {
             var options = typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().DeclaredMethods.ToList();
             Assert.Equal(2, options.Count(mi => mi.Name == "DummyRollingFile"));
-            var suppliedArguments = new Dictionary<string, string>
+            var suppliedArguments = new Dictionary<string, IConfigurationArgumentValue>
             {
-                {"pathFormat", "C:\\" }
+                {"pathFormat", new StringArgumentValue(() => "C:\\") }
             };
 
             var selected = ConfigurationReader.SelectConfigurationMethod(options, "DummyRollingFile", suppliedArguments);
@@ -36,10 +27,10 @@ namespace Serilog.Settings.Configuration.Tests
         {
             var options = typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().DeclaredMethods.ToList();
             Assert.Equal(2, options.Count(mi => mi.Name == "DummyRollingFile"));
-            var suppliedArguments = new Dictionary<string, string>()
+            var suppliedArguments = new Dictionary<string, IConfigurationArgumentValue>()
             {
-                { "pathFormat", "C:\\" },
-                { "formatter", "SomeFormatter, SomeAssembly" }
+                { "pathFormat", new StringArgumentValue(() => "C:\\") },
+                { "formatter", new StringArgumentValue(() => "SomeFormatter, SomeAssembly") }
             };
 
             var selected = ConfigurationReader.SelectConfigurationMethod(options, "DummyRollingFile", suppliedArguments);

--- a/test/Serilog.Settings.Configuration.Tests/StringArgumentValueTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/StringArgumentValueTests.cs
@@ -1,0 +1,19 @@
+﻿using Serilog.Formatting;
+using Serilog.Formatting.Json;
+using Xunit;
+
+namespace Serilog.Settings.Configuration.Tests
+{
+    public class StringArgumentValueTests
+    {
+        [Fact]
+        public void StringValuesConvertToDefaultInstancesIfTargetIsInterface()
+        {
+            var stringArgumentValue = new StringArgumentValue(() => "Serilog.Formatting.Json.JsonFormatter, Serilog");
+
+            var result = stringArgumentValue.ConvertTo(typeof(ITextFormatter));
+
+            Assert.IsType<JsonFormatter>(result);
+        }
+    }
+}


### PR DESCRIPTION
- fixes [#37](https://github.com/serilog/serilog-settings-configuration/issues/37)
- adds `Serilog.Sinks.Async` support
- adds `LoggingLevelSwitch` parameter type support

Basically implementation based on converters around `Action<TSerilogConfiguration>` parameter types from configuration extensions methods.
