### PR TITLE
Fix #47, #23 [multiple sinks of the same kind; environment-friendly syntax)

### DIFF
--- a/sample/Sample/appsettings.json
+++ b/sample/Sample/appsettings.json
@@ -8,38 +8,36 @@
         "MyApp.Something.Tricky": "Verbose"
       }
     },
-    "WriteTo": [
-      {
-        "Name": "Logger",
-        "Args": {
-          "configureLogger": {
-            "WriteTo": [
-              {
-                "Name": "LiterateConsole",
-                "Args": {
-                  "outputTemplate": "[{Timestamp:HH:mm:ss} {SourceContext} [{Level}] {Message}{NewLine}{Exception}"
-                }
-              }
-            ]
-          },
-          "restrictedToMinimumLevel": "Debug"
-        }
-      },
-      {
-        "Name": "Async",
-        "Args": {
-          "configure": [
+    "WriteTo:Sublogger": {
+      "Name": "Logger",
+      "Args": {
+        "configureLogger": {
+          "WriteTo": [
             {
-              "Name": "File",
+              "Name": "LiterateConsole",
               "Args": {
-                "path": "%TEMP%\\Logs\\serilog-configuration-sample.txt",
-                "outputTemplate": "{Timestamp:o} [{Level:u3}] ({Application}/{MachineName}/{ThreadId}) {Message}{NewLine}{Exception}"
+                "outputTemplate": "[{Timestamp:HH:mm:ss} {SourceContext} [{Level}] {Message}{NewLine}{Exception}"
               }
             }
           ]
-        }
-      }      
-    ],
+        },
+        "restrictedToMinimumLevel": "Debug"
+      }
+    },
+    "WriteTo:Async": {
+      "Name": "Async",
+      "Args": {
+        "configure": [
+          {
+            "Name": "File",
+            "Args": {
+              "path": "%TEMP%\\Logs\\serilog-configuration-sample.txt",
+              "outputTemplate": "{Timestamp:o} [{Level:u3}] ({Application}/{MachineName}/{ThreadId}) {Message}{NewLine}{Exception}"
+            }
+          }
+        ]
+      }
+    },
     "Enrich": ["FromLogContext", "WithMachineName", "WithThreadId"],
     "Properties": {
       "Application": "Sample"

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
@@ -3,11 +3,139 @@ using Serilog.Formatting;
 using Xunit;
 using System.Reflection;
 using System.Linq;
+using Serilog.Settings.Configuration.Tests.Support;
 
 namespace Serilog.Settings.Configuration.Tests
 {
     public class ConfigurationReaderTests
     {
+        readonly ConfigurationReader _configurationReader;
+
+        public ConfigurationReaderTests()
+        {
+            _configurationReader = new ConfigurationReader(JsonStringConfigSource.LoadSection(@"{ 'Serilog': {  } }", "Serilog"), null);
+        }
+
+        [Fact]
+        public void WriteToSupportSimplifiedSyntax()
+        {
+            var json = @"
+{
+    'WriteTo': [ 'LiterateConsole', 'DiagnosticTrace' ]
+}";
+
+            var result = _configurationReader.GetMethodCalls(JsonStringConfigSource.LoadSection(json, "WriteTo"));
+            Assert.Equal(2, result.Count);
+            Assert.True(result.Contains("LiterateConsole"));
+            Assert.True(result.Contains("DiagnosticTrace"));
+
+            Assert.Equal(1, result["LiterateConsole"].Count());
+            Assert.Equal(1, result["DiagnosticTrace"].Count());
+        }
+
+        [Fact]
+        public void WriteToSupportExpandedSyntaxWithoutArgs()
+        {
+            var json = @"
+{
+    'WriteTo': [ {
+        'Name': 'LiterateConsole'
+    }]
+}";
+
+            var result = _configurationReader.GetMethodCalls(JsonStringConfigSource.LoadSection(json, "WriteTo"));
+            Assert.Equal(1, result.Count);
+            Assert.True(result.Contains("LiterateConsole"));
+
+            Assert.Equal(1, result["LiterateConsole"].Count());
+        }
+
+        [Fact]
+        public void WriteToSupportExpandedSyntaxWithArgs()
+        {
+            var json = @"
+{
+    'WriteTo': [ {
+        'Name': 'LiterateConsole',
+        'Args': {
+            'outputTemplate': '{Message}'
+        },
+    }]
+}";
+
+            var result = _configurationReader.GetMethodCalls(JsonStringConfigSource.LoadSection(json, "WriteTo"));
+
+            Assert.Equal(1, result.Count);
+            Assert.True(result.Contains("LiterateConsole"));
+
+            Assert.Equal(1, result["LiterateConsole"].Count());
+
+            var args = result["LiterateConsole"].Single().Cast<KeyValuePair<string, IConfigurationArgumentValue>>().ToArray();
+
+            Assert.Equal(1, args.Length);
+            Assert.Equal("outputTemplate", args[0].Key);
+            Assert.Equal("{Message}", args[0].Value.ConvertTo(typeof(string)));
+        }
+
+        [Fact]
+        public void WriteToSupportMultipleSinksOfTheSameKind()
+        {
+            var json = @"
+{
+    'WriteTo': [
+      {
+        'Name': 'LiterateConsole',
+        'Args': {
+            'outputTemplate': '{Message}'
+          },
+      },
+      'DiagnosticTrace'
+    ],
+    'WriteTo:File1': {
+        'Name': 'File',
+        'Args': {
+            'outputTemplate': '{Message}'
+        },
+    },
+    'WriteTo:File2': {
+        'Name': 'File',
+        'Args': {
+            'outputTemplate': '{Message}'
+        },
+    }
+}";
+
+            var result = _configurationReader.GetMethodCalls(JsonStringConfigSource.LoadSection(json, "WriteTo"));
+
+            Assert.Equal(3, result.Count);
+            Assert.True(result.Contains("LiterateConsole"));
+            Assert.True(result.Contains("DiagnosticTrace"));
+            Assert.True(result.Contains("File"));
+
+            Assert.Equal(1, result["LiterateConsole"].Count());
+            Assert.Equal(1, result["DiagnosticTrace"].Count());
+            Assert.Equal(2, result["File"].Count());
+        }
+
+        [Fact]
+        public void Enrich_SupportSimplifiedSyntax()
+        {
+            var json = @"
+{
+    'Enrich': [ 'FromLogContext', 'WithMachineName', 'WithThreadId' ]
+}";
+
+            var result = _configurationReader.GetMethodCalls(JsonStringConfigSource.LoadSection(json, "Enrich"));
+            Assert.Equal(3, result.Count);
+            Assert.True(result.Contains("FromLogContext"));
+            Assert.True(result.Contains("WithMachineName"));
+            Assert.True(result.Contains("WithThreadId"));
+
+            Assert.Equal(1, result["FromLogContext"].Count());
+            Assert.Equal(1, result["WithMachineName"].Count());
+            Assert.Equal(1, result["WithThreadId"].Count());
+        }
+
         [Fact]
         public void CallableMethodsAreSelected()
         {

--- a/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
+++ b/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
 
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Serilog.Settings.Configuration.Tests/Support/JsonStringConfigSource.cs
+++ b/test/Serilog.Settings.Configuration.Tests/Support/JsonStringConfigSource.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Json;
+
+using System.IO;
+
+namespace Serilog.Settings.Configuration.Tests.Support
+{
+    class JsonStringConfigSource : IConfigurationSource
+    {
+        readonly string _json;
+
+        public JsonStringConfigSource(string json)
+        {
+            _json = json;
+        }
+
+        public IConfigurationProvider Build(IConfigurationBuilder builder)
+        {
+            return new JsonStringConfigProvider(_json);
+        }
+
+        public static IConfigurationSection LoadSection(string json, string section)
+        {
+            return new ConfigurationBuilder().Add(new JsonStringConfigSource(json)).Build().GetSection(section);
+        }
+
+        class JsonStringConfigProvider : JsonConfigurationProvider
+        {
+            readonly string _json;
+
+            public JsonStringConfigProvider(string json) : base(new JsonConfigurationSource { Optional = true })
+            {
+                _json = json;
+            }
+
+            public override void Load()
+            {
+                Load(StringToStream(_json));
+            }
+
+            static Stream StringToStream(string str)
+            {
+                var memStream = new MemoryStream();
+                var textWriter = new StreamWriter(memStream);
+                textWriter.Write(str);
+                textWriter.Flush();
+                memStream.Seek(0, SeekOrigin.Begin);
+
+                return memStream;
+            }
+        }
+    }
+}


### PR DESCRIPTION
- fixes [#47](https://github.com/serilog/serilog-settings-configuration/issues/47)
- fixes [#23](https://github.com/serilog/serilog-settings-configuration/issues/23)

#23 is a side effect of fixing #47 (as already pointed out in previous [pr](https://github.com/serilog/serilog-settings-configuration/pull/28) that syntax was already supported by the `Microsoft.Extensions.Configuration`. Fixing #47 just enables it.)