### PR TITLE
Updated StringArgumentValue.ConvertTo to let the class not found exce…

### DIFF
--- a/src/Serilog.Settings.Configuration/Settings/Configuration/StringArgumentValue.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/StringArgumentValue.cs
@@ -56,7 +56,7 @@ namespace Serilog.Settings.Configuration
 
             if (toTypeInfo.IsInterface && !string.IsNullOrWhiteSpace(argumentValue))
             {
-                var type = Type.GetType(argumentValue.Trim(), throwOnError: false);
+                var type = Type.GetType(argumentValue.Trim());
                 if (type != null)
                 {
                     var ctor = type.GetTypeInfo().DeclaredConstructors.FirstOrDefault(ci =>


### PR DESCRIPTION
…ption go

I lost a full afternoon looking for documentation or on stackoverflow to find out how to set an object instance to a method's "Args" in my appsettings.json file (same thing applies to the web.config I guess).

If I had recieved the correct exception, I would have known right away how to format the class name by looking at the stack trace and into the `Type.GetType` documentation.

I ran all unit tests and everything works fine with that change.

Hope it helps and you'll accept my pull request...

See my stackoverflow question [here](https://stackoverflow.com/questions/46082251/how-to-set-my-own-keygenerator-instance-in-appsettings-json) for some more background.