### PR TITLE
Support AuditTo in configuration

### DIFF
--- a/serilog-settings-configuration.sln
+++ b/serilog-settings-configuration.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.10
+VisualStudioVersion = 15.0.27130.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{4E41FD57-5FAB-4E3C-B16E-463DE98338BC}"
 EndProject
@@ -24,6 +24,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Serilog.Settings.Configurat
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Sample", "sample\Sample\Sample.csproj", "{A00E5E32-54F9-401A-BBA1-2F6FCB6366CD}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestDummies", "test\TestDummies\TestDummies.csproj", "{B7CF5068-DD19-4868-A268-5280BDE90361}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -42,6 +44,10 @@ Global
 		{A00E5E32-54F9-401A-BBA1-2F6FCB6366CD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A00E5E32-54F9-401A-BBA1-2F6FCB6366CD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A00E5E32-54F9-401A-BBA1-2F6FCB6366CD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B7CF5068-DD19-4868-A268-5280BDE90361}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B7CF5068-DD19-4868-A268-5280BDE90361}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B7CF5068-DD19-4868-A268-5280BDE90361}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B7CF5068-DD19-4868-A268-5280BDE90361}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -50,5 +56,9 @@ Global
 		{21FF98ED-E68C-4A67-B241-C8D6122FAD7D} = {4E41FD57-5FAB-4E3C-B16E-463DE98338BC}
 		{F793C6E8-C40A-4018-8884-C97E2BE38A54} = {D551DCB0-7771-4D01-BEBD-F7B57D1CF0E3}
 		{A00E5E32-54F9-401A-BBA1-2F6FCB6366CD} = {D24872B9-57F3-42A7-BC8D-F9DA222FCE1B}
+		{B7CF5068-DD19-4868-A268-5280BDE90361} = {D551DCB0-7771-4D01-BEBD-F7B57D1CF0E3}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {485F8843-42D7-4267-B5FB-20FE9181DEE9}
 	EndGlobalSection
 EndGlobal

--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -19,6 +19,7 @@
     
     <!-- Don't reference the full NETStandard.Library -->
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
+    <RootNamespace>Serilog</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -13,13 +13,14 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Serilog.Settings.Configuration</PackageId>
     <PackageTags>serilog;json</PackageTags>
-    <PackageIconUrl>http://serilog.net/images/serilog-configuration-nuget.png</PackageIconUrl>
-    <PackageProjectUrl>http://serilog.net</PackageProjectUrl>
-    <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageIconUrl>https://serilog.net/images/serilog-configuration-nuget.png</PackageIconUrl>
+    <PackageProjectUrl>https://github.com/serilog/serilog-settings-configuration</PackageProjectUrl>
+    <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     
     <!-- Don't reference the full NETStandard.Library -->
     <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <RootNamespace>Serilog</RootNamespace>
+    <Version>2.5.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -25,7 +25,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.0.0" />
-    <PackageReference Include="Serilog" Version="2.5.0" />
+    <PackageReference Include="Serilog" Version="2.6.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -24,7 +24,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.0.0" />
-    <PackageReference Include="Serilog" Version="2.0.0" />
+    <PackageReference Include="Serilog" Version="2.5.0" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -41,6 +41,7 @@ namespace Serilog.Settings.Configuration
             ApplyEnrichment(loggerConfiguration);
             ApplyFilters(loggerConfiguration);
             ApplySinks(loggerConfiguration);
+            ApplyAuditSinks(loggerConfiguration);
         }        
 
         void ApplyMinimumLevel(LoggerConfiguration loggerConfiguration)
@@ -95,6 +96,16 @@ namespace Serilog.Settings.Configuration
             {
                 var methodCalls = GetMethodCalls(writeToDirective);
                 CallConfigurationMethods(methodCalls, FindSinkConfigurationMethods(_configurationAssemblies), loggerConfiguration.WriteTo);
+            }
+        }
+
+        void ApplyAuditSinks(LoggerConfiguration loggerConfiguration)
+        {
+            var auditToDirective = _configuration.GetSection("AuditTo");
+            if (auditToDirective != null)
+            {
+                var methodCalls = GetMethodCalls(auditToDirective);
+                CallConfigurationMethods(methodCalls, FindAuditSinkConfigurationMethods(_configurationAssemblies), loggerConfiguration.AuditTo);
             }
         }
 
@@ -256,6 +267,13 @@ namespace Serilog.Settings.Configuration
             var found = FindConfigurationMethods(configurationAssemblies, typeof(LoggerSinkConfiguration));
             if (configurationAssemblies.Contains(typeof(LoggerSinkConfiguration).GetTypeInfo().Assembly))
                 found.Add(GetSurrogateConfigurationMethod<LoggerSinkConfiguration, Action<LoggerConfiguration>, LoggingLevelSwitch>((c, a, s) => Logger(c, a, s)));
+
+            return found;
+        }
+
+        internal static IList<MethodInfo> FindAuditSinkConfigurationMethods(IEnumerable<Assembly> configurationAssemblies)
+        {
+            var found = FindConfigurationMethods(configurationAssemblies, typeof(LoggerAuditSinkConfiguration));
 
             return found;
         }

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -66,27 +66,30 @@ namespace Serilog.Settings.Configuration.Tests
             Assert.Equal(0, DummyRollingFileAuditSink.Emitted.Count);
         }
 
-        //[Fact]
-        //public void AuditSinksAreConfigured()
-        //{
-        //    var settings = new Dictionary<string, string>
-        //    {
-        //        ["using:TestDummies"] = typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().Assembly.FullName,
-        //        ["audit-to:DummyRollingFile.pathFormat"] = "C:\\"
-        //    };
+        [Fact]
+        public void AuditSinksAreConfigured()
+        {
+            var json = @"{
+                ""Serilog"": {            
+                    ""Using"": [""TestDummies""],
+                    ""AuditTo"": [{
+                        ""Name"": ""DummyRollingFile"",
+                        ""Args"": {""pathFormat"" : ""C:\\""}
+                    }]        
+                }
+            }";
 
-        //    var log = new LoggerConfiguration()
-        //        .ReadFrom.KeyValuePairs(settings)
-        //        .CreateLogger();
+            var log = ConfigFromJson(json)
+                .CreateLogger();
+            
+            DummyRollingFileSink.Emitted.Clear();
+            DummyRollingFileAuditSink.Emitted.Clear();
 
-        //    DummyRollingFileSink.Emitted.Clear();
-        //    DummyRollingFileAuditSink.Emitted.Clear();
+            log.Write(Some.InformationEvent());
 
-        //    log.Write(Some.InformationEvent());
-
-        //    Assert.Equal(0, DummyRollingFileSink.Emitted.Count);
-        //    Assert.Equal(1, DummyRollingFileAuditSink.Emitted.Count);
-        //}
+            Assert.Equal(0, DummyRollingFileSink.Emitted.Count);
+            Assert.Equal(1, DummyRollingFileAuditSink.Emitted.Count);
+        }
 
         [Fact]
         public void TestMinimumLevelOverrides()

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -4,6 +4,7 @@ using Serilog.Events;
 using Serilog.Settings.Configuration.Tests.Support;
 using TestDummies;
 using TestDummies.Console;
+using TestDummies.Console.Themes;
 using Xunit;
 
 namespace Serilog.Settings.Configuration.Tests
@@ -176,25 +177,25 @@ namespace Serilog.Settings.Configuration.Tests
             Assert.IsType<CustomConsoleTheme>(DummyConsoleSink.Theme);
         }
 
-        //[Fact]
-        //public void SinksAreConfiguredWithStaticMember()
-        //{
-        //    var json = @"{
-        //        ""Serilog"": {            
-        //            ""Using"": [""TestDummies""],
-        //            ""WriteTo"": [{
-        //                ""Name"": ""DummyConsole"",
-        //                ""Args"": {""theme"" : ""TestDummies.Console.Themes.ConsoleThemes::Theme1, TestDummies""}
-        //            }]        
-        //        }
-        //    }";
+        [Fact]
+        public void SinksAreConfiguredWithStaticMember()
+        {
+            var json = @"{
+                ""Serilog"": {            
+                    ""Using"": [""TestDummies""],
+                    ""WriteTo"": [{
+                        ""Name"": ""DummyConsole"",
+                        ""Args"": {""theme"" : ""TestDummies.Console.Themes.ConsoleThemes::Theme1, TestDummies""}
+                    }]        
+                }
+            }";
 
-        //    DummyConsoleSink.Theme = null;
+            DummyConsoleSink.Theme = null;
 
-        //    ConfigFromJson(json)
-        //        .CreateLogger();
+            ConfigFromJson(json)
+                .CreateLogger();
 
-        //    Assert.Equal(ConsoleThemes.Theme1, DummyConsoleSink.Theme);
-        //}
+            Assert.Equal(ConsoleThemes.Theme1, DummyConsoleSink.Theme);
+        }
     }
 }

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -1,0 +1,166 @@
+﻿using System;
+using Microsoft.Extensions.Configuration;
+using Serilog.Events;
+using Serilog.Settings.Configuration.Tests.Support;
+using TestDummies;
+using TestDummies.Console;
+using Xunit;
+
+namespace Serilog.Settings.Configuration.Tests
+{
+    public class ConfigurationSettingsTests
+    {
+        private static LoggerConfiguration ConfigFromJson(string jsonString)
+        {
+            var config = new ConfigurationBuilder().AddJsonString(jsonString).Build();
+            return new LoggerConfiguration()
+                .ReadFrom.Configuration(config);
+        }
+
+        [Fact]
+        public void PropertyEnrichmentIsApplied()
+        {
+            LogEvent evt = null;
+
+            var json = @"{
+                ""Serilog"": {            
+                    ""Properties"": {
+                        ""App"": ""Test""
+                    }
+                }
+            }";
+            
+            var log = ConfigFromJson(json)
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("Has a test property");
+
+            Assert.NotNull(evt);
+            Assert.Equal("Test", evt.Properties["App"].LiteralValue());
+        }
+
+
+        [Fact]
+        public void SinksAreConfigured()
+        {
+            var json = @"{
+                ""Serilog"": {            
+                    ""Using"": [""TestDummies""],
+                    ""WriteTo"": [{
+                        ""Name"": ""DummyRollingFile"",
+                        ""Args"": {""pathFormat"" : ""C:\\""}
+                    }]        
+                }
+            }";
+
+            var log = ConfigFromJson(json)
+                .CreateLogger();
+
+            DummyRollingFileSink.Emitted.Clear();
+            DummyRollingFileAuditSink.Emitted.Clear();
+
+            log.Write(Some.InformationEvent());
+
+            Assert.Equal(1, DummyRollingFileSink.Emitted.Count);
+            Assert.Equal(0, DummyRollingFileAuditSink.Emitted.Count);
+        }
+
+        //[Fact]
+        //public void AuditSinksAreConfigured()
+        //{
+        //    var settings = new Dictionary<string, string>
+        //    {
+        //        ["using:TestDummies"] = typeof(DummyLoggerConfigurationExtensions).GetTypeInfo().Assembly.FullName,
+        //        ["audit-to:DummyRollingFile.pathFormat"] = "C:\\"
+        //    };
+
+        //    var log = new LoggerConfiguration()
+        //        .ReadFrom.KeyValuePairs(settings)
+        //        .CreateLogger();
+
+        //    DummyRollingFileSink.Emitted.Clear();
+        //    DummyRollingFileAuditSink.Emitted.Clear();
+
+        //    log.Write(Some.InformationEvent());
+
+        //    Assert.Equal(0, DummyRollingFileSink.Emitted.Count);
+        //    Assert.Equal(1, DummyRollingFileAuditSink.Emitted.Count);
+        //}
+
+        [Fact]
+        public void TestMinimumLevelOverrides()
+        {
+            var json = @"{
+                ""Serilog"": {
+                    ""MinimumLevel"" : {
+                        ""Override"" : {
+                            ""System"" : ""Warning""
+                        }
+                    }        
+                }
+            }";
+
+            LogEvent evt = null;
+
+            var log = ConfigFromJson(json)
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            var systemLogger = log.ForContext<WeakReference>();
+            systemLogger.Write(Some.InformationEvent());
+
+            Assert.Null(evt);
+
+            systemLogger.Warning("Bad things");
+            Assert.NotNull(evt);
+
+            evt = null;
+            log.Write(Some.InformationEvent());
+            Assert.NotNull(evt);
+        }
+
+        [Fact]
+        public void SinksWithAbstractParamsAreConfiguredWithTypeName()
+        {
+            var json = @"{
+                ""Serilog"": {            
+                    ""Using"": [""TestDummies""],
+                    ""WriteTo"": [{
+                        ""Name"": ""DummyConsole"",
+                        ""Args"": {""theme"" : ""Serilog.Settings.Configuration.Tests.Support.CustomConsoleTheme, Serilog.Settings.Configuration.Tests""}
+                    }]        
+                }
+            }";
+
+            DummyConsoleSink.Theme = null;
+
+            ConfigFromJson(json)
+                .CreateLogger();
+
+            Assert.NotNull(DummyConsoleSink.Theme);
+            Assert.IsType<CustomConsoleTheme>(DummyConsoleSink.Theme);
+        }
+
+        //[Fact]
+        //public void SinksAreConfiguredWithStaticMember()
+        //{
+        //    var json = @"{
+        //        ""Serilog"": {            
+        //            ""Using"": [""TestDummies""],
+        //            ""WriteTo"": [{
+        //                ""Name"": ""DummyConsole"",
+        //                ""Args"": {""theme"" : ""TestDummies.Console.Themes.ConsoleThemes::Theme1, TestDummies""}
+        //            }]        
+        //        }
+        //    }";
+
+        //    DummyConsoleSink.Theme = null;
+
+        //    ConfigFromJson(json)
+        //        .CreateLogger();
+
+        //    Assert.Equal(ConsoleThemes.Theme1, DummyConsoleSink.Theme);
+        //}
+    }
+}

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -40,6 +40,37 @@ namespace Serilog.Settings.Configuration.Tests
             Assert.Equal("Test", evt.Properties["App"].LiteralValue());
         }
 
+        [Theory]
+        [InlineData("extended syntax",
+            @"{
+                ""Serilog"": {            
+                    ""Using"": [""TestDummies""],
+                    ""WriteTo"": [
+                        { ""Name"": ""DummyConsole""},
+                        { ""Name"": ""DummyWithLevelSwitch""},
+                    ]        
+                }
+            }")]
+        [InlineData("simplified syntax",
+            @"{
+                ""Serilog"": {            
+                    ""Using"": [""TestDummies""],
+                    ""WriteTo"": [""DummyConsole"", ""DummyWithLevelSwitch"" ]        
+                }
+            }")]
+        public void ParameterlessSinksAreConfigured(string syntax, string json)
+        {
+            var log = ConfigFromJson(json)
+                .CreateLogger();
+
+            DummyConsoleSink.Emitted.Clear();
+            DummyWithLevelSwitchSink.Emitted.Clear();
+
+            log.Write(Some.InformationEvent());
+
+            Assert.Equal(1, DummyConsoleSink.Emitted.Count);
+            Assert.Equal(1, DummyWithLevelSwitchSink.Emitted.Count);
+        }
 
         [Fact]
         public void SinksAreConfigured()

--- a/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
+++ b/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
@@ -10,6 +10,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Serilog.Settings.Configuration\Serilog.Settings.Configuration.csproj" />
+    <ProjectReference Include="..\TestDummies\TestDummies.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Serilog.Settings.Configuration.Tests/Support/ConfigurationBuilderExtensions.cs
+++ b/test/Serilog.Settings.Configuration.Tests/Support/ConfigurationBuilderExtensions.cs
@@ -1,0 +1,12 @@
+﻿using Microsoft.Extensions.Configuration;
+
+namespace Serilog.Settings.Configuration.Tests.Support
+{
+    public static class ConfigurationBuilderExtensions
+    {
+        public static IConfigurationBuilder AddJsonString(this IConfigurationBuilder builder, string json)
+        {
+            return builder.Add(new JsonStringConfigSource(json));
+        }
+    }
+}

--- a/test/Serilog.Settings.Configuration.Tests/Support/CustomConsoleTheme.cs
+++ b/test/Serilog.Settings.Configuration.Tests/Support/CustomConsoleTheme.cs
@@ -1,0 +1,8 @@
+﻿using TestDummies.Console.Themes;
+
+namespace Serilog.Settings.Configuration.Tests.Support
+{
+    class CustomConsoleTheme : ConsoleTheme
+    {
+    }
+}

--- a/test/Serilog.Settings.Configuration.Tests/Support/DelegatingSink.cs
+++ b/test/Serilog.Settings.Configuration.Tests/Support/DelegatingSink.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Settings.Configuration.Tests.Support
+{
+    public class DelegatingSink : ILogEventSink
+    {
+        readonly Action<LogEvent> _write;
+
+        public DelegatingSink(Action<LogEvent> write)
+        {
+            if (write == null) throw new ArgumentNullException(nameof(write));
+            _write = write;
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            _write(logEvent);
+        }
+
+        public static LogEvent GetLogEvent(Action<ILogger> writeAction)
+        {
+            LogEvent result = null;
+            var l = new LoggerConfiguration()
+                .MinimumLevel.Verbose()
+                .WriteTo.Sink(new DelegatingSink(le => result = le))
+                .CreateLogger();
+
+            writeAction(l);
+            return result;
+        }
+    }
+}

--- a/test/Serilog.Settings.Configuration.Tests/Support/Extensions.cs
+++ b/test/Serilog.Settings.Configuration.Tests/Support/Extensions.cs
@@ -1,0 +1,12 @@
+﻿using Serilog.Events;
+
+namespace Serilog.Settings.Configuration.Tests.Support
+{
+    public static class Extensions
+    {
+        public static object LiteralValue(this LogEventPropertyValue @this)
+        {
+            return ((ScalarValue)@this).Value;
+        }
+    }
+}

--- a/test/Serilog.Settings.Configuration.Tests/Support/Some.cs
+++ b/test/Serilog.Settings.Configuration.Tests/Support/Some.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Parsing;
+
+namespace Serilog.Settings.Configuration.Tests.Support
+{
+    static class Some
+    {
+        static int Counter;
+
+        public static int Int()
+        {
+            return Interlocked.Increment(ref Counter);
+        }
+
+        public static decimal Decimal()
+        {
+            return Int() + 0.123m;
+        }
+
+        public static string String(string tag = null)
+        {
+            return (tag ?? "") + "__" + Int();
+        }
+
+        public static TimeSpan TimeSpan()
+        {
+            return System.TimeSpan.FromMinutes(Int());
+        }
+
+        public static DateTime Instant()
+        {
+            return new DateTime(2012, 10, 28) + TimeSpan();
+        }
+
+        public static DateTimeOffset OffsetInstant()
+        {
+            return new DateTimeOffset(Instant());
+        }
+
+        public static LogEvent LogEvent(string sourceContext, DateTimeOffset? timestamp = null, LogEventLevel level = LogEventLevel.Information)
+        {
+            return new LogEvent(timestamp ?? OffsetInstant(), level,
+                null, MessageTemplate(),
+                new List<LogEventProperty> { new LogEventProperty(Constants.SourceContextPropertyName, new ScalarValue(sourceContext)) });
+        }
+
+        public static LogEvent LogEvent(DateTimeOffset? timestamp = null, LogEventLevel level = LogEventLevel.Information)
+        {
+            return new LogEvent(timestamp ?? OffsetInstant(), level,
+                null, MessageTemplate(), Enumerable.Empty<LogEventProperty>());
+        }
+
+        public static LogEvent InformationEvent(DateTimeOffset? timestamp = null)
+        {
+            return LogEvent(timestamp, LogEventLevel.Information);
+        }
+
+        public static LogEvent DebugEvent(DateTimeOffset? timestamp = null)
+        {
+            return LogEvent(timestamp, LogEventLevel.Debug);
+        }
+
+        public static LogEvent WarningEvent(DateTimeOffset? timestamp = null)
+        {
+            return LogEvent(timestamp, LogEventLevel.Warning);
+        }
+
+        public static LogEventProperty LogEventProperty()
+        {
+            return new LogEventProperty(String(), new ScalarValue(Int()));
+        }
+
+        public static string NonexistentTempFilePath()
+        {
+            return Path.Combine(Path.GetTempPath(), Guid.NewGuid() + ".txt");
+        }
+
+        public static string TempFilePath()
+        {
+            return Path.GetTempFileName();
+        }
+
+        public static string TempFolderPath()
+        {
+            var dir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(dir);
+            return dir;
+        }
+
+        public static MessageTemplate MessageTemplate()
+        {
+            return new MessageTemplateParser().Parse(String());
+        }
+    }
+}

--- a/test/TestDummies/Console/DummyConsoleSink.cs
+++ b/test/TestDummies/Console/DummyConsoleSink.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Serilog.Core;
+using Serilog.Events;
+using TestDummies.Console.Themes;
+
+namespace TestDummies.Console
+{
+    public class DummyConsoleSink : ILogEventSink
+    {
+        public DummyConsoleSink(ConsoleTheme theme = null)
+        {
+            Theme = theme ?? ConsoleTheme.None;
+        }
+
+        [ThreadStatic]
+        public static ConsoleTheme Theme;
+
+        public void Emit(LogEvent logEvent)
+        {
+        }
+    }
+
+}
+

--- a/test/TestDummies/Console/DummyConsoleSink.cs
+++ b/test/TestDummies/Console/DummyConsoleSink.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Serilog.Core;
 using Serilog.Events;
 using TestDummies.Console.Themes;
@@ -15,8 +16,14 @@ namespace TestDummies.Console
         [ThreadStatic]
         public static ConsoleTheme Theme;
 
+        [ThreadStatic]
+        // ReSharper disable ThreadStaticFieldHasInitializer
+        public static List<LogEvent> Emitted = new List<LogEvent>();
+        // ReSharper restore ThreadStaticFieldHasInitializer
+
         public void Emit(LogEvent logEvent)
         {
+            Emitted.Add(logEvent);
         }
     }
 

--- a/test/TestDummies/Console/Themes/ConcreteConsoleTheme.cs
+++ b/test/TestDummies/Console/Themes/ConcreteConsoleTheme.cs
@@ -1,0 +1,6 @@
+namespace TestDummies.Console.Themes
+{
+    class ConcreteConsoleTheme : ConsoleTheme
+    {
+    }
+}

--- a/test/TestDummies/Console/Themes/ConsoleTheme.cs
+++ b/test/TestDummies/Console/Themes/ConsoleTheme.cs
@@ -1,0 +1,7 @@
+namespace TestDummies.Console.Themes
+{
+    public abstract class ConsoleTheme
+    {
+        public static ConsoleTheme None { get; } = new EmptyConsoleTheme();
+    }
+}

--- a/test/TestDummies/Console/Themes/ConsoleThemes.cs
+++ b/test/TestDummies/Console/Themes/ConsoleThemes.cs
@@ -1,0 +1,7 @@
+namespace TestDummies.Console.Themes
+{
+    public static class ConsoleThemes
+    {
+        public static ConsoleTheme Theme1 { get; } = new ConcreteConsoleTheme();
+    }
+}

--- a/test/TestDummies/Console/Themes/EmptyConsoleTheme.cs
+++ b/test/TestDummies/Console/Themes/EmptyConsoleTheme.cs
@@ -1,0 +1,6 @@
+namespace TestDummies.Console.Themes
+{
+    class EmptyConsoleTheme : ConsoleTheme
+    {
+    }
+}

--- a/test/TestDummies/DummyLoggerConfigurationExtensions.cs
+++ b/test/TestDummies/DummyLoggerConfigurationExtensions.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using Serilog;
+using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Configuration;
+using Serilog.Core;
+using TestDummies.Console;
+using TestDummies.Console.Themes;
+
+namespace TestDummies
+{
+    public static class DummyLoggerConfigurationExtensions
+    {
+        public static LoggerConfiguration WithDummyThreadId(this LoggerEnrichmentConfiguration enrich)
+        {
+            return enrich.With(new DummyThreadIdEnricher());
+        }
+
+        public static LoggerConfiguration DummyRollingFile(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            string pathFormat,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            string outputTemplate = null,
+            IFormatProvider formatProvider = null)
+        {
+            return loggerSinkConfiguration.Sink(new DummyRollingFileSink(), restrictedToMinimumLevel);
+        }
+
+        public static LoggerConfiguration DummyRollingFile(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            ITextFormatter formatter,
+            string pathFormat,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
+        {
+            return loggerSinkConfiguration.Sink(new DummyRollingFileSink(), restrictedToMinimumLevel);
+        }
+
+        public static LoggerConfiguration DummyRollingFile(
+            this LoggerAuditSinkConfiguration loggerSinkConfiguration,
+            string pathFormat,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            string outputTemplate = null,
+            IFormatProvider formatProvider = null)
+        {
+            return loggerSinkConfiguration.Sink(new DummyRollingFileAuditSink(), restrictedToMinimumLevel);
+        }
+
+        public static LoggerConfiguration DummyWithLevelSwitch(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch controlLevelSwitch = null)
+        {
+            return loggerSinkConfiguration.Sink(new DummyWithLevelSwitchSink(controlLevelSwitch), restrictedToMinimumLevel);
+        }
+
+        public static LoggerConfiguration DummyConsole(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            ConsoleTheme theme = null)
+        {
+            return loggerSinkConfiguration.Sink(new DummyConsoleSink(theme), restrictedToMinimumLevel);
+        }
+
+        public static LoggerConfiguration Dummy(
+            this LoggerSinkConfiguration loggerSinkConfiguration,
+            Action<LoggerSinkConfiguration> wrappedSinkAction)
+        {
+            return LoggerSinkConfiguration.Wrap(
+                loggerSinkConfiguration,
+                s => new DummyWrappingSink(s),
+                wrappedSinkAction);
+        }
+        
+    }
+}

--- a/test/TestDummies/DummyRollingFileAuditSink.cs
+++ b/test/TestDummies/DummyRollingFileAuditSink.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies
+{
+    public class DummyRollingFileAuditSink : ILogEventSink
+    {
+        [ThreadStatic]
+        // ReSharper disable ThreadStaticFieldHasInitializer
+        public static List<LogEvent> Emitted = new List<LogEvent>();
+        // ReSharper restore ThreadStaticFieldHasInitializer
+
+        public void Emit(LogEvent logEvent)
+        {
+            Emitted.Add(logEvent);
+        }
+    }
+}

--- a/test/TestDummies/DummyRollingFileSink.cs
+++ b/test/TestDummies/DummyRollingFileSink.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies
+{
+    public class DummyRollingFileSink : ILogEventSink
+    {
+        [ThreadStatic]
+        // ReSharper disable ThreadStaticFieldHasInitializer
+        public static List<LogEvent> Emitted = new List<LogEvent>();
+        // ReSharper restore ThreadStaticFieldHasInitializer
+
+        public void Emit(LogEvent logEvent)
+        {
+            Emitted.Add(logEvent);
+        }
+    }
+}

--- a/test/TestDummies/DummyThreadIdEnricher.cs
+++ b/test/TestDummies/DummyThreadIdEnricher.cs
@@ -1,0 +1,12 @@
+﻿using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies
+{
+    public class DummyThreadIdEnricher : ILogEventEnricher
+    {
+        public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
+        {          
+        }
+    }
+}

--- a/test/TestDummies/DummyWithLevelSwitchSink.cs
+++ b/test/TestDummies/DummyWithLevelSwitchSink.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies
+{
+    public class DummyWithLevelSwitchSink : ILogEventSink
+    {
+        public DummyWithLevelSwitchSink(LoggingLevelSwitch loggingControlLevelSwitch)
+        {
+            ControlLevelSwitch = loggingControlLevelSwitch;
+        }
+
+        [ThreadStatic]
+        public static LoggingLevelSwitch ControlLevelSwitch;
+
+        [ThreadStatic]
+        // ReSharper disable ThreadStaticFieldHasInitializer
+        public static List<LogEvent> Emitted = new List<LogEvent>();
+        // ReSharper restore ThreadStaticFieldHasInitializer
+
+        public void Emit(LogEvent logEvent)
+        {
+            Emitted.Add(logEvent);
+        }
+    }
+}

--- a/test/TestDummies/DummyWrappingSink.cs
+++ b/test/TestDummies/DummyWrappingSink.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using Serilog.Core;
+using Serilog.Events;
+using System.Collections.Generic;
+
+namespace TestDummies
+{
+    public class DummyWrappingSink : ILogEventSink
+    {
+        [ThreadStatic]
+        // ReSharper disable ThreadStaticFieldHasInitializer
+        public static List<LogEvent> Emitted = new List<LogEvent>();
+        // ReSharper restore ThreadStaticFieldHasInitializer
+
+        private readonly ILogEventSink _sink;
+
+        public DummyWrappingSink(ILogEventSink sink)
+        {
+            _sink = sink;
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            Emitted.Add(logEvent);
+            _sink.Emit(logEvent);
+        }
+    }
+}

--- a/test/TestDummies/Properties/AssemblyInfo.cs
+++ b/test/TestDummies/Properties/AssemblyInfo.cs
@@ -1,0 +1,18 @@
+﻿using System.Reflection;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TestDummies")]
+[assembly: AssemblyTrademark("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("2bb12ce5-c867-43bd-ae5d-253fe3248c7f")]

--- a/test/TestDummies/TestDummies.csproj
+++ b/test/TestDummies/TestDummies.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.5.0" />
+    <PackageReference Include="Serilog" Version="2.6.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">

--- a/test/TestDummies/TestDummies.csproj
+++ b/test/TestDummies/TestDummies.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net452;netstandard1.3</TargetFrameworks>
+    <AssemblyName>TestDummies</AssemblyName>
+    <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <PackageId>TestDummies</PackageId>
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Serilog" Version="2.5.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Fixes #80

- handles AuditTo
- adds more general tests with sample json config snippets
- update Serilog reference to v2.5.à