### PR TITLE
project files updated

### DIFF
--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -13,8 +13,15 @@
     <ProjectReference Include="..\..\src\Serilog.Settings.Configuration\Serilog.Settings.Configuration.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.1" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Serilog.Sinks.Async" Version="1.0.1" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.RollingFile" Version="3.0.0" />

--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -4,7 +4,7 @@
     <Description>Microsoft.Extensions.Configuration (appsettings.json) support for Serilog.</Description>
     <VersionPrefix>3.0.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>net451;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net451</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Settings.Configuration</AssemblyName>
@@ -16,16 +16,20 @@
     <PackageIconUrl>https://serilog.net/images/serilog-configuration-nuget.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/serilog/serilog-settings-configuration</PackageProjectUrl>
     <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
-    
-    <!-- Don't reference the full NETStandard.Library -->
-    <DisableImplicitFrameworkReferences>true</DisableImplicitFrameworkReferences>
     <RootNamespace>Serilog</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
     <PackageReference Include="Serilog" Version="2.6.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
   </ItemGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net451' ">

--- a/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
+++ b/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
@@ -1,5 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <!-- 
+  Because this is a multi-targeted project/solution, run tests from the command line
+  with the current working directory set to the location of this csproj. Tests will not
+  execute within the VS IDE as of version 15.6.5 (April 2018).
+  
+  dotnet test [dash dash]framework net452
+  dotnet test [dash dash]framework netcoreapp2.0
+  
+  (XML doesn't allow double-dashes in comments...)
+  -->
+  
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <AssemblyName>Serilog.Settings.Configuration.Tests</AssemblyName>
@@ -13,12 +24,18 @@
     <ProjectReference Include="..\TestDummies\TestDummies.csproj" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.0.1" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />
-
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Per #83, updated and tested references to `Microsoft.Extensions.DependencyModel` 
and `Microsoft.Extensions.Configuration.*`.

Confirmed both framework sample versions also run correctly. In all project files, old .NET Framework and .NET Standard refs were updated separately (conditional TFMs) to latest supporting versions. Also added a comment to the test project explaining how to run the multi-targeted tests from the command line (it was new to me, I suspect it is not commonly known).