### PR TITLE
Multiple value exception, fixes #103

### DIFF
--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -222,8 +222,14 @@ namespace Serilog.Settings.Configuration
             {
                 IConfigurationArgumentValue argumentValue;
 
+                // Reject configurations where an element has both scalar and complex
+                // values as a result of reading multiple configuration sources.
                 if (argumentSection.Value != null && argumentSection.GetChildren().Any())
-                    throw new InvalidOperationException($"Combined configuration sources must result in a discrete value (string, int, etc.) or complex value (section, list, etc.), not both. Argument: {argumentSection.Path}");
+                    throw new InvalidOperationException(
+                        $"The value for the argument {argumentSection.Path} is assigned different value " +
+                        "types in more than one configuration source. Ensure all configurations consistently " +
+                        "use either a scalar (int, string, boolean) or a complex (array, section, list, " +
+                        "POCO, etc.) type for this argument value.");
 
                 if (argumentSection.Value != null)
                 {

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -226,7 +226,7 @@ namespace Serilog.Settings.Configuration
                 // values as a result of reading multiple configuration sources.
                 if (argumentSection.Value != null && argumentSection.GetChildren().Any())
                     throw new InvalidOperationException(
-                        $"The value for the argument {argumentSection.Path} is assigned different value " +
+                        $"The value for the argument '{argumentSection.Path}' is assigned different value " +
                         "types in more than one configuration source. Ensure all configurations consistently " +
                         "use either a scalar (int, string, boolean) or a complex (array, section, list, " +
                         "POCO, etc.) type for this argument value.");

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -221,6 +221,10 @@ namespace Serilog.Settings.Configuration
             IConfigurationArgumentValue GetArgumentValue(IConfigurationSection argumentSection)
             {
                 IConfigurationArgumentValue argumentValue;
+
+                if(argumentSection.Value != null && argumentSection.GetChildren().Any())
+                    throw new InvalidOperationException($"Combined configuration sources must result in a discrete value (string, int, etc.) or complex value (section, list, etc.), not both. Argument: {argumentSection.Path}");
+
                 if (argumentSection.Value != null)
                 {
                     argumentValue = new StringArgumentValue(() => argumentSection.Value, argumentSection.GetReloadToken);

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -222,7 +222,7 @@ namespace Serilog.Settings.Configuration
             {
                 IConfigurationArgumentValue argumentValue;
 
-                if(argumentSection.Value != null && argumentSection.GetChildren().Any())
+                if (argumentSection.Value != null && argumentSection.GetChildren().Any())
                     throw new InvalidOperationException($"Combined configuration sources must result in a discrete value (string, int, etc.) or complex value (section, list, etc.), not both. Argument: {argumentSection.Path}");
 
                 if (argumentSection.Value != null)

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -562,7 +562,7 @@ namespace Serilog.Settings.Configuration.Tests
 
         [Trait("Bugfix", "#103")]
         [Fact]
-        public void MultipleArgumentValuesThrowsInvalidOperationException()
+        public void InconsistentComplexVsScalarArgumentValuesThrowsIOE()
         {
             var jsonDiscreteValue = @"{
                 ""Serilog"": {            

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -594,8 +594,8 @@ namespace Serilog.Settings.Configuration.Tests
             var ex = Assert.Throws<InvalidOperationException>(()
                 => ConfigFromJson(jsonDiscreteValue, jsonComplexValue));
 
-            Assert.Contains("Combined configuration sources", ex.Message);
-            Assert.Contains("pathFormat", ex.Message);
+            Assert.Contains("The value for the argument", ex.Message);
+            Assert.Contains("'Serilog:WriteTo:0:Args:pathFormat'", ex.Message);
         }
     }
 }

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -15,7 +15,8 @@ namespace Serilog.Settings.Configuration.Tests
         static LoggerConfiguration ConfigFromJson(string jsonString, string secondJsonSource = null)
         {
             var builder = new ConfigurationBuilder().AddJsonString(jsonString);
-            if(secondJsonSource != null) builder.AddJsonString(secondJsonSource);
+            if (secondJsonSource != null)
+                builder.AddJsonString(secondJsonSource);
             var config = builder.Build();
             return new LoggerConfiguration()
                 .ReadFrom.Configuration(config);
@@ -33,7 +34,7 @@ namespace Serilog.Settings.Configuration.Tests
                     }
                 }
             }";
-            
+
             var log = ConfigFromJson(json)
                 .WriteTo.Sink(new DelegatingSink(e => evt = e))
                 .CreateLogger();
@@ -116,7 +117,7 @@ namespace Serilog.Settings.Configuration.Tests
 
             var log = ConfigFromJson(json)
                 .CreateLogger();
-            
+
             DummyRollingFileSink.Emitted.Clear();
             DummyRollingFileAuditSink.Emitted.Clear();
 
@@ -229,7 +230,7 @@ namespace Serilog.Settings.Configuration.Tests
                     ""LevelSwitches"": {""switchNameNotStartingWithDollar"" : ""Warning"" }
                 }
             }";
-            
+
             var ex = Assert.Throws<FormatException>(() => ConfigFromJson(json));
 
             Assert.Contains("\"switchNameNotStartingWithDollar\"", ex.Message);
@@ -273,7 +274,7 @@ namespace Serilog.Settings.Configuration.Tests
                     }
                 }
             }";
-            
+
             var ex = Assert.Throws<InvalidOperationException>(() =>
                 ConfigFromJson(json)
                     .CreateLogger());
@@ -334,7 +335,7 @@ namespace Serilog.Settings.Configuration.Tests
                     }]      
                 }
             }";
-            
+
             var ex = Assert.Throws<InvalidOperationException>(() =>
                 ConfigFromJson(json)
                     .CreateLogger());
@@ -546,8 +547,8 @@ namespace Serilog.Settings.Configuration.Tests
                     }
                 }]        
             }
-            }";            
-             
+            }";
+
             var log = ConfigFromJson(json)
             .CreateLogger();
 
@@ -590,7 +591,8 @@ namespace Serilog.Settings.Configuration.Tests
             // the multiple values are recognized; it will never attempt to locate
             // a matching argument.
 
-            var ex = Assert.Throws<InvalidOperationException>(() => ConfigFromJson(jsonDiscreteValue, jsonComplexValue));
+            var ex = Assert.Throws<InvalidOperationException>(()
+                => ConfigFromJson(jsonDiscreteValue, jsonComplexValue));
 
             Assert.Contains("Combined configuration sources", ex.Message);
             Assert.Contains("pathFormat", ex.Message);


### PR DESCRIPTION
Throws `InvalidOperationException` if multiple configuration sources results in an ambiguous argument value. See #103 for details.