### PR TITLE
Destructure support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Configuration is read from the `Serilog` section.
     ],
     "Enrich": ["FromLogContext", "WithMachineName", "WithThreadId"],
     "Destructure": [
+      { "Name": "With", "Args": { "policy": "Sample.CustomPolicy, Sample" } },
       { "Name": "ToMaximumDepth", "Args": { "maximumDestructuringDepth": 4 } },
       { "Name": "ToMaximumStringLength", "Args": { "maximumStringLength": 100 } },
       { "Name": "ToMaximumCollectionCount", "Args": { "maximumCollectionCount": 10 } }

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ Configuration is read from the `Serilog` section.
       { "Name": "File", "Args": { "path": "%TEMP%\\Logs\\serilog-configuration-sample.txt" } }
     ],
     "Enrich": ["FromLogContext", "WithMachineName", "WithThreadId"],
+    "Destructure": [
+      { "Name": "ToMaximumDepth", "Args": { "maximumDestructuringDepth": 4 } },
+      { "Name": "ToMaximumStringLength", "Args": { "maximumStringLength": 100 } },
+      { "Name": "ToMaximumCollectionCount", "Args": { "maximumCollectionCount": 10 } }
+    ],
     "Properties": {
 		"Application": "Sample"
     }

--- a/sample/Sample/Program.cs
+++ b/sample/Sample/Program.cs
@@ -32,12 +32,23 @@ namespace Sample
                 logger.ForContext(Constants.SourceContextPropertyName, "Microsoft").Error("Hello, world!");
                 logger.ForContext(Constants.SourceContextPropertyName, "MyApp.Something.Tricky").Verbose("Hello, world!");
 
-                Console.WriteLine();
+                logger.Information("Destructure with max object nesting depth:\n{@NestedObject}",
+                    new { FiveDeep = new { Two = new { Three = new { Four = new { Five = "the end" } } } } });
+
+                logger.Information("Destructure with max string length:\n{@LongString}",
+                    new { TwentyChars = "0123456789abcdefghij" });
+
+                logger.Information("Destructure with max collection count:\n{@BigData}",
+                    new { TenItems = new string[] { "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten" } });
+
+                Console.WriteLine("\nPress \"q\" to quit, or any other key to run again.\n");
             }
             while (!args.Contains("--run-once") && (Console.ReadKey().KeyChar != 'q'));
         }
     }
 
+    // The filter syntax in the sample configuration file is
+    // processed by the Serilog.Filters.Expressions package.
     public class CustomFilter : ILogEventFilter
     {
         public bool IsEnabled(LogEvent logEvent)

--- a/sample/Sample/appsettings.json
+++ b/sample/Sample/appsettings.json
@@ -43,6 +43,20 @@
     "Properties": {
       "Application": "Sample"
     },
+    "Destructure": [
+      {
+        "Name": "ToMaximumDepth",
+        "Args": { "maximumDestructuringDepth": 3 }
+      },
+      {
+        "Name": "ToMaximumStringLength",
+        "Args": { "maximumStringLength": 10 }
+      },
+      {
+        "Name": "ToMaximumCollectionCount",
+        "Args": { "maximumCollectionCount": 5 }
+      }
+    ],
     "Filter": [
       {
         "Name": "ByIncludingOnly",

--- a/sample/Sample/appsettings.json
+++ b/sample/Sample/appsettings.json
@@ -45,6 +45,10 @@
     },
     "Destructure": [
       {
+        "Name": "With",
+        "Args": { "policy": "Sample.CustomPolicy, Sample" }
+      },
+      {
         "Name": "ToMaximumDepth",
         "Args": { "maximumDestructuringDepth": 3 }
       },

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -57,6 +57,7 @@ namespace Serilog.Settings.Configuration
             ApplyMinimumLevel(loggerConfiguration, declaredLevelSwitches);
             ApplyEnrichment(loggerConfiguration, declaredLevelSwitches);
             ApplyFilters(loggerConfiguration, declaredLevelSwitches);
+            ApplyDestructuring(loggerConfiguration, declaredLevelSwitches);
             ApplySinks(loggerConfiguration, declaredLevelSwitches);
             ApplyAuditSinks(loggerConfiguration, declaredLevelSwitches);
         }
@@ -149,6 +150,16 @@ namespace Serilog.Settings.Configuration
             {
                 var methodCalls = GetMethodCalls(filterDirective);
                 CallConfigurationMethods(methodCalls, FindFilterConfigurationMethods(_configurationAssemblies), loggerConfiguration.Filter, declaredLevelSwitches);
+            }
+        }
+
+        void ApplyDestructuring(LoggerConfiguration loggerConfiguration, IReadOnlyDictionary<string, LoggingLevelSwitch> declaredLevelSwitches)
+        {
+            var filterDirective = _section.GetSection("Destructure");
+            if(filterDirective.GetChildren().Any())
+            {
+                var methodCalls = GetMethodCalls(filterDirective);
+                CallConfigurationMethods(methodCalls, FindDestructureConfigurationMethods(_configurationAssemblies), loggerConfiguration.Destructure, declaredLevelSwitches);
             }
         }
 
@@ -339,7 +350,7 @@ namespace Serilog.Settings.Configuration
 
         internal static IList<MethodInfo> FindSinkConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
         {
-            var found = FindConfigurationMethods(configurationAssemblies, typeof(LoggerSinkConfiguration));
+            var found = FindConfigurationExtensions(configurationAssemblies, typeof(LoggerSinkConfiguration));
             if (configurationAssemblies.Contains(typeof(LoggerSinkConfiguration).GetTypeInfo().Assembly))
                 found.Add(GetSurrogateConfigurationMethod<LoggerSinkConfiguration, Action<LoggerConfiguration>, LoggingLevelSwitch>((c, a, s) => Logger(c, a, LevelAlias.Minimum, s)));
 
@@ -348,30 +359,44 @@ namespace Serilog.Settings.Configuration
 
         internal static IList<MethodInfo> FindAuditSinkConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
         {
-            var found = FindConfigurationMethods(configurationAssemblies, typeof(LoggerAuditSinkConfiguration));
+            var found = FindConfigurationExtensions(configurationAssemblies, typeof(LoggerAuditSinkConfiguration));
 
             return found;
         }
 
         internal static IList<MethodInfo> FindFilterConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
         {
-            var found = FindConfigurationMethods(configurationAssemblies, typeof(LoggerFilterConfiguration));
+            var found = FindConfigurationExtensions(configurationAssemblies, typeof(LoggerFilterConfiguration));
             if (configurationAssemblies.Contains(typeof(LoggerFilterConfiguration).GetTypeInfo().Assembly))
                 found.Add(GetSurrogateConfigurationMethod<LoggerFilterConfiguration, ILogEventFilter, object>((c, f, _) => With(c, f)));
 
             return found;
         }
 
+        internal static IList<MethodInfo> FindDestructureConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
+        {
+            var found = FindConfigurationExtensions(configurationAssemblies, typeof(LoggerDestructuringConfiguration));
+            if(configurationAssemblies.Contains(typeof(LoggerDestructuringConfiguration).GetTypeInfo().Assembly))
+            {
+                found.Add(GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, IDestructuringPolicy, object>((c, d, _) => With(c, d)));
+                found.Add(GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, int, object>((c, m, _) => ToMaximumDepth(c, m)));
+                found.Add(GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, int, object>((c, m, _) => ToMaximumStringLength(c, m)));
+                found.Add(GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, int, object>((c, m, _) => ToMaximumCollectionCount(c, m)));
+            }
+
+            return found;
+        }
+
         internal static IList<MethodInfo> FindEventEnricherConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
         {
-            var found = FindConfigurationMethods(configurationAssemblies, typeof(LoggerEnrichmentConfiguration));
+            var found = FindConfigurationExtensions(configurationAssemblies, typeof(LoggerEnrichmentConfiguration));
             if (configurationAssemblies.Contains(typeof(LoggerEnrichmentConfiguration).GetTypeInfo().Assembly))
                 found.Add(GetSurrogateConfigurationMethod<LoggerEnrichmentConfiguration, object, object>((c, _, __) => FromLogContext(c)));
 
             return found;
         }
 
-        internal static IList<MethodInfo> FindConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies, Type configType)
+        internal static IList<MethodInfo> FindConfigurationExtensions(IReadOnlyCollection<Assembly> configurationAssemblies, Type configType)
         {
             return configurationAssemblies
                 .SelectMany(a => a.ExportedTypes
@@ -383,15 +408,34 @@ namespace Serilog.Settings.Configuration
                 .ToList();
         }
 
-        // don't support (yet?) arrays in the parameter list (ILogEventEnricher[])
+        /*
+        Pass-through calls to various Serilog config methods which are
+        implemented as instance methods rather than extension methods. The
+        FindXXXConfigurationMethods calls (above) use these to add method
+        invocation expressions as surrogates so that SelectConfigurationMethod
+        has a way to match and invoke these instance methods.
+        */
+
+        // TODO: add overload for array argument (ILogEventEnricher[])
         internal static LoggerConfiguration With(LoggerFilterConfiguration loggerFilterConfiguration, ILogEventFilter filter)
             => loggerFilterConfiguration.With(filter);
 
-        // Unlike the other configuration methods, FromLogContext is an instance method rather than an extension.
+        // TODO: add overload for array argument (IDestructuringPolicy[])
+        internal static LoggerConfiguration With(LoggerDestructuringConfiguration loggerDestructuringConfiguration, IDestructuringPolicy policy)
+            => loggerDestructuringConfiguration.With(policy);
+
+        internal static LoggerConfiguration ToMaximumDepth(LoggerDestructuringConfiguration loggerDestructuringConfiguration, int maximumDestructuringDepth)
+            => loggerDestructuringConfiguration.ToMaximumDepth(maximumDestructuringDepth);
+
+        internal static LoggerConfiguration ToMaximumStringLength(LoggerDestructuringConfiguration loggerDestructuringConfiguration, int maximumStringLength)
+            => loggerDestructuringConfiguration.ToMaximumStringLength(maximumStringLength);
+
+        internal static LoggerConfiguration ToMaximumCollectionCount(LoggerDestructuringConfiguration loggerDestructuringConfiguration, int maximumCollectionCount)
+            => loggerDestructuringConfiguration.ToMaximumCollectionCount(maximumCollectionCount);
+
         internal static LoggerConfiguration FromLogContext(LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
             => loggerEnrichmentConfiguration.FromLogContext();
 
-        // Unlike the other configuration methods, Logger is an instance method rather than an extension.
         internal static LoggerConfiguration Logger(
             LoggerSinkConfiguration loggerSinkConfiguration,
             Action<LoggerConfiguration> configureLogger,

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -350,7 +350,7 @@ namespace Serilog.Settings.Configuration
 
         internal static IList<MethodInfo> FindSinkConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
         {
-            var found = FindConfigurationExtensions(configurationAssemblies, typeof(LoggerSinkConfiguration));
+            var found = FindConfigurationExtensionMethods(configurationAssemblies, typeof(LoggerSinkConfiguration));
             if (configurationAssemblies.Contains(typeof(LoggerSinkConfiguration).GetTypeInfo().Assembly))
                 found.Add(GetSurrogateConfigurationMethod<LoggerSinkConfiguration, Action<LoggerConfiguration>, LoggingLevelSwitch>((c, a, s) => Logger(c, a, LevelAlias.Minimum, s)));
 
@@ -359,14 +359,14 @@ namespace Serilog.Settings.Configuration
 
         internal static IList<MethodInfo> FindAuditSinkConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
         {
-            var found = FindConfigurationExtensions(configurationAssemblies, typeof(LoggerAuditSinkConfiguration));
+            var found = FindConfigurationExtensionMethods(configurationAssemblies, typeof(LoggerAuditSinkConfiguration));
 
             return found;
         }
 
         internal static IList<MethodInfo> FindFilterConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
         {
-            var found = FindConfigurationExtensions(configurationAssemblies, typeof(LoggerFilterConfiguration));
+            var found = FindConfigurationExtensionMethods(configurationAssemblies, typeof(LoggerFilterConfiguration));
             if (configurationAssemblies.Contains(typeof(LoggerFilterConfiguration).GetTypeInfo().Assembly))
                 found.Add(GetSurrogateConfigurationMethod<LoggerFilterConfiguration, ILogEventFilter, object>((c, f, _) => With(c, f)));
 
@@ -375,7 +375,7 @@ namespace Serilog.Settings.Configuration
 
         internal static IList<MethodInfo> FindDestructureConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
         {
-            var found = FindConfigurationExtensions(configurationAssemblies, typeof(LoggerDestructuringConfiguration));
+            var found = FindConfigurationExtensionMethods(configurationAssemblies, typeof(LoggerDestructuringConfiguration));
             if(configurationAssemblies.Contains(typeof(LoggerDestructuringConfiguration).GetTypeInfo().Assembly))
             {
                 found.Add(GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, IDestructuringPolicy, object>((c, d, _) => With(c, d)));
@@ -389,14 +389,14 @@ namespace Serilog.Settings.Configuration
 
         internal static IList<MethodInfo> FindEventEnricherConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
         {
-            var found = FindConfigurationExtensions(configurationAssemblies, typeof(LoggerEnrichmentConfiguration));
+            var found = FindConfigurationExtensionMethods(configurationAssemblies, typeof(LoggerEnrichmentConfiguration));
             if (configurationAssemblies.Contains(typeof(LoggerEnrichmentConfiguration).GetTypeInfo().Assembly))
                 found.Add(GetSurrogateConfigurationMethod<LoggerEnrichmentConfiguration, object, object>((c, _, __) => FromLogContext(c)));
 
             return found;
         }
 
-        internal static IList<MethodInfo> FindConfigurationExtensions(IReadOnlyCollection<Assembly> configurationAssemblies, Type configType)
+        internal static IList<MethodInfo> FindConfigurationExtensionMethods(IReadOnlyCollection<Assembly> configurationAssemblies, Type configType)
         {
             return configurationAssemblies
                 .SelectMany(a => a.ExportedTypes


### PR DESCRIPTION
Added support for destructure `With` and max-limit settings, also opening up destructuring features to additional configuration through extension methods in other packages, as discussed in #106.

- ConfigurationReader:
  - add ApplyDestructuring
  - add FindDestructureConfigurationMethods
  - added surrogates for several destructure config methods
  - add comments explaining method-level surrogates
  - renamed FindConfigurationMethods to FindConfigurationExtensions
- three unit tests modeled on Serilog's own destructure tests
- README updated with a few lines of JSON demonstrating the settings
- changes to sample program
  - config for Destructure max string length and max collection depth
  - log events to demonstrate Destructure config
  - comment explaining Filter syntax is from S.F.Expressions package

#### Update
- renamed FindConfigurationExtensions toFindConfigurationExtensionMethods
- added IDestructuringPolicy example to sample program and README docs
