### PR TITLE
Add support for .Destructure.AsScalar(Type scalarType) 

### DIFF
--- a/sample/Sample/Program.cs
+++ b/sample/Sample/Program.cs
@@ -40,7 +40,7 @@ namespace Sample
                     new { TwentyChars = "0123456789abcdefghij" });
 
                 logger.Information("Destructure with max collection count:\n{@BigData}",
-                    new { TenItems = new string[] { "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten" } });
+                    new { TenItems = new[] { "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten" } });
 
                 logger.Information("Destructure with policy to strip password:\n{@LoginData}",
                     new LoginData { Username = "BGates", Password = "isityearoflinuxyet" });

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -155,10 +155,10 @@ namespace Serilog.Settings.Configuration
 
         void ApplyDestructuring(LoggerConfiguration loggerConfiguration, IReadOnlyDictionary<string, LoggingLevelSwitch> declaredLevelSwitches)
         {
-            var filterDirective = _section.GetSection("Destructure");
-            if(filterDirective.GetChildren().Any())
+            var destructureDirective = _section.GetSection("Destructure");
+            if (destructureDirective.GetChildren().Any())
             {
-                var methodCalls = GetMethodCalls(filterDirective);
+                var methodCalls = GetMethodCalls(destructureDirective);
                 CallConfigurationMethods(methodCalls, FindDestructureConfigurationMethods(_configurationAssemblies), loggerConfiguration.Destructure, declaredLevelSwitches);
             }
         }
@@ -221,9 +221,11 @@ namespace Serilog.Settings.Configuration
                  where child.Value == null
                  let name = GetSectionName(child)
                  let callArgs = (from argument in child.GetSection("Args").GetChildren()
-                                 select new {
+                                 select new
+                                 {
                                      Name = argument.Key,
-                                     Value = GetArgumentValue(argument) }).ToDictionary(p => p.Name, p => p.Value)
+                                     Value = GetArgumentValue(argument)
+                                 }).ToDictionary(p => p.Name, p => p.Value)
                  select new { Name = name, Args = callArgs }))
                      .ToLookup(p => p.Name, p => p.Args);
 
@@ -330,7 +332,7 @@ namespace Serilog.Settings.Configuration
                                 select directive.Key == null ? p.DefaultValue : directive.Value.ConvertTo(p.ParameterType, declaredLevelSwitches)).ToList();
 
                     var parm = methodInfo.GetParameters().FirstOrDefault(i => i.ParameterType == typeof(IConfiguration));
-                    if(parm != null) call[parm.Position - 1] = _configuration;
+                    if (parm != null) call[parm.Position - 1] = _configuration;
 
                     call.Insert(0, receiver);
 
@@ -376,7 +378,7 @@ namespace Serilog.Settings.Configuration
         internal static IList<MethodInfo> FindDestructureConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
         {
             var found = FindConfigurationExtensionMethods(configurationAssemblies, typeof(LoggerDestructuringConfiguration));
-            if(configurationAssemblies.Contains(typeof(LoggerDestructuringConfiguration).GetTypeInfo().Assembly))
+            if (configurationAssemblies.Contains(typeof(LoggerDestructuringConfiguration).GetTypeInfo().Assembly))
             {
                 found.Add(GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, IDestructuringPolicy, object>((c, d, _) => With(c, d)));
                 found.Add(GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, int, object>((c, m, _) => ToMaximumDepth(c, m)));

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -384,6 +384,7 @@ namespace Serilog.Settings.Configuration
                 found.Add(GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, int, object>((c, m, _) => ToMaximumDepth(c, m)));
                 found.Add(GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, int, object>((c, m, _) => ToMaximumStringLength(c, m)));
                 found.Add(GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, int, object>((c, m, _) => ToMaximumCollectionCount(c, m)));
+                found.Add(GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, Type, object>((c, t, _) => AsScalar(c, t)));
             }
 
             return found;
@@ -434,6 +435,9 @@ namespace Serilog.Settings.Configuration
 
         internal static LoggerConfiguration ToMaximumCollectionCount(LoggerDestructuringConfiguration loggerDestructuringConfiguration, int maximumCollectionCount)
             => loggerDestructuringConfiguration.ToMaximumCollectionCount(maximumCollectionCount);
+
+        internal static LoggerConfiguration AsScalar(LoggerDestructuringConfiguration loggerDestructuringConfiguration, Type scalarType)
+            => loggerDestructuringConfiguration.AsScalar(scalarType);
 
         internal static LoggerConfiguration FromLogContext(LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
             => loggerEnrichmentConfiguration.FromLogContext();

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/StringArgumentValue.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/StringArgumentValue.cs
@@ -27,7 +27,8 @@ namespace Serilog.Settings.Configuration
         static readonly Dictionary<Type, Func<string, object>> ExtendedTypeConversions = new Dictionary<Type, Func<string, object>>
             {
                 { typeof(Uri), s => new Uri(s) },
-                { typeof(TimeSpan), s => TimeSpan.Parse(s) }
+                { typeof(TimeSpan), s => TimeSpan.Parse(s) },
+                { typeof(Type), s => Type.GetType(s, throwOnError:true) },
             };
 
         public object ConvertTo(Type toType, IReadOnlyDictionary<string, LoggingLevelSwitch> declaredLevelSwitches)

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/SurrogateConfigurationMethods.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/SurrogateConfigurationMethods.cs
@@ -1,0 +1,99 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Reflection;
+using Serilog.Configuration;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Settings.Configuration
+{
+    /// <summary>
+    /// Contains "fake extension" methods for the Serilog configuration API.
+    /// By default the settings knows how to find extension methods, but some configuration
+    /// are actually "regular" method calls and would not be found otherwise.
+    ///
+    /// This static class contains internal methods that can be used instead.
+    ///
+    /// </summary>
+    static class SurrogateConfigurationMethods
+    {
+        public static IEnumerable<MethodInfo> WriteTo
+        {
+            get
+            {
+                yield return GetSurrogateConfigurationMethod<LoggerSinkConfiguration, Action<LoggerConfiguration>, LoggingLevelSwitch>((c, a, s) => Logger(c, a, LevelAlias.Minimum, s));
+            }
+        }
+
+        public static IEnumerable<MethodInfo> Filter
+        {
+            get
+            {
+                yield return GetSurrogateConfigurationMethod<LoggerFilterConfiguration, ILogEventFilter, object>((c, f, _) => With(c, f));
+            }
+        }
+
+        public static IEnumerable<MethodInfo> Destructure
+        {
+            get
+            {
+                yield return GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, IDestructuringPolicy, object>((c, d, _) => With(c, d));
+                yield return GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, int, object>((c, m, _) => ToMaximumDepth(c, m));
+                yield return GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, int, object>((c, m, _) => ToMaximumStringLength(c, m));
+                yield return GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, int, object>((c, m, _) => ToMaximumCollectionCount(c, m));
+                yield return GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, Type, object>((c, t, _) => AsScalar(c, t));
+            }
+        }
+
+        public static IEnumerable<MethodInfo> Enrich
+        {
+            get
+            {
+                yield return GetSurrogateConfigurationMethod<LoggerEnrichmentConfiguration, object, object>((c, _, __) => FromLogContext(c));
+            }
+        }
+
+        static MethodInfo GetSurrogateConfigurationMethod<TConfiguration, TArg1, TArg2>(Expression<Action<TConfiguration, TArg1, TArg2>> method)
+            => (method.Body as MethodCallExpression)?.Method;
+
+        /*
+        Pass-through calls to various Serilog config methods which are
+        implemented as instance methods rather than extension methods. The
+        FindXXXConfigurationMethods calls (above) use these to add method
+        invocation expressions as surrogates so that SelectConfigurationMethod
+        has a way to match and invoke these instance methods.
+        */
+
+        // TODO: add overload for array argument (ILogEventEnricher[])
+        static LoggerConfiguration With(LoggerFilterConfiguration loggerFilterConfiguration, ILogEventFilter filter)
+            => loggerFilterConfiguration.With(filter);
+
+        // TODO: add overload for array argument (IDestructuringPolicy[])
+        static LoggerConfiguration With(LoggerDestructuringConfiguration loggerDestructuringConfiguration, IDestructuringPolicy policy)
+            => loggerDestructuringConfiguration.With(policy);
+
+        static LoggerConfiguration ToMaximumDepth(LoggerDestructuringConfiguration loggerDestructuringConfiguration, int maximumDestructuringDepth)
+            => loggerDestructuringConfiguration.ToMaximumDepth(maximumDestructuringDepth);
+
+        static LoggerConfiguration ToMaximumStringLength(LoggerDestructuringConfiguration loggerDestructuringConfiguration, int maximumStringLength)
+            => loggerDestructuringConfiguration.ToMaximumStringLength(maximumStringLength);
+
+        static LoggerConfiguration ToMaximumCollectionCount(LoggerDestructuringConfiguration loggerDestructuringConfiguration, int maximumCollectionCount)
+            => loggerDestructuringConfiguration.ToMaximumCollectionCount(maximumCollectionCount);
+
+        static LoggerConfiguration AsScalar(LoggerDestructuringConfiguration loggerDestructuringConfiguration, Type scalarType)
+            => loggerDestructuringConfiguration.AsScalar(scalarType);
+
+        static LoggerConfiguration FromLogContext(LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
+            => loggerEnrichmentConfiguration.FromLogContext();
+
+        // Unlike the other configuration methods, Logger is an instance method rather than an extension.
+        static LoggerConfiguration Logger(
+            LoggerSinkConfiguration loggerSinkConfiguration,
+            Action<LoggerConfiguration> configureLogger,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null)
+            => loggerSinkConfiguration.Logger(configureLogger, restrictedToMinimumLevel, levelSwitch);
+    }
+}

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -703,5 +703,53 @@ namespace Serilog.Settings.Configuration.Tests
 
             Assert.Equal("\"hardcoded\"", formattedProperty);
         }
+
+        [Fact]
+        public void DestructuringAsScalarIsAppliedWithShortTypeName()
+        {
+            var json = @"{
+                ""Serilog"": {
+                    ""Destructure"": [
+                    {
+                        ""Name"": ""AsScalar"",
+                        ""Args"": { ""scalarType"": ""System.Version"" }
+                    }]
+                }
+            }";
+
+            LogEvent evt = null;
+            var log = ConfigFromJson(json)
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("Destructuring as scalar {@Scalarized}", new Version(2,3));
+            var prop = evt.Properties["Scalarized"];
+
+            Assert.IsType<ScalarValue>(prop);
+        }
+
+        [Fact]
+        public void DestructuringAsScalarIsAppliedWithAssemblyQualifiedName()
+        {
+            var json = $@"{{
+                ""Serilog"": {{
+                    ""Destructure"": [
+                    {{
+                        ""Name"": ""AsScalar"",
+                        ""Args"": {{ ""scalarType"": ""{typeof(Version).AssemblyQualifiedName}"" }}
+                    }}]
+                }}
+            }}";
+
+            LogEvent evt = null;
+            var log = ConfigFromJson(json)
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Information("Destructuring as scalar {@Scalarized}", new Version(2,3));
+            var prop = evt.Properties["Scalarized"];
+
+            Assert.IsType<ScalarValue>(prop);
+        }
     }
 }

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -679,5 +679,29 @@ namespace Serilog.Settings.Configuration.Tests
             var result = evt.Properties["X"].ToString();
             return result;
         }
+
+        [Fact]
+        public void DestructuringWithCustomExtensionMethodIsApplied()
+        {
+            var json = @"{
+                ""Serilog"": {
+                    ""Using"": [""TestDummies""],
+                    ""Destructure"": [
+                    {
+                        ""Name"": ""WithDummyHardCodedString"",
+                        ""Args"": { ""hardCodedString"": ""hardcoded"" }
+                    }]
+                }
+            }";
+
+            LogEvent evt = null;
+            var log = ConfigFromJson(json)
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+            log.Information("Destructuring with hard-coded policy {@Input}", new { Foo = "Bar" });
+            var formattedProperty = evt.Properties["Input"].ToString();
+
+            Assert.Equal("\"hardcoded\"", formattedProperty);
+        }
     }
 }

--- a/test/Serilog.Settings.Configuration.Tests/StringArgumentValueTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/StringArgumentValueTests.cs
@@ -163,5 +163,27 @@ namespace Serilog.Settings.Configuration.Tests
             Assert.Contains("$mySwitch", ex.Message);
             Assert.Contains("\"LevelSwitches\":{\"$mySwitch\":", ex.Message);
         }
+
+        [Fact]
+        public void StringValuesConvertToTypeFromShortTypeName()
+        {
+            var shortTypeName = "System.Version";
+            var stringArgumentValue = new StringArgumentValue(() => shortTypeName);
+
+            var actual = (Type)stringArgumentValue.ConvertTo(typeof(Type), new Dictionary<string, LoggingLevelSwitch>());
+
+            Assert.Equal(typeof(Version), actual);
+        }
+
+        [Fact]
+        public void StringValuesConvertToTypeFromAssemblyQualifiedName()
+        {
+            var assemblyQualifiedName = typeof(Version).AssemblyQualifiedName;
+            var stringArgumentValue = new StringArgumentValue(() => assemblyQualifiedName);
+
+            var actual = (Type)stringArgumentValue.ConvertTo(typeof(Type), new Dictionary<string, LoggingLevelSwitch>());
+
+            Assert.Equal(typeof(Version), actual);
+        }
     }
 }

--- a/test/TestDummies/DummyHardCodedStringDestructuringPolicy.cs
+++ b/test/TestDummies/DummyHardCodedStringDestructuringPolicy.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies
+{
+    public class DummyHardCodedStringDestructuringPolicy : IDestructuringPolicy
+    {
+        readonly string _hardCodedString;
+
+        public DummyHardCodedStringDestructuringPolicy(string hardCodedString)
+        {
+            _hardCodedString = hardCodedString ?? throw new ArgumentNullException(nameof(hardCodedString));
+        }
+
+        public bool TryDestructure(object value, ILogEventPropertyValueFactory propertyValueFactory, out LogEventPropertyValue result)
+        {
+            result = new ScalarValue(_hardCodedString);
+            return true;
+        }
+    }
+}

--- a/test/TestDummies/DummyLoggerConfigurationExtensions.cs
+++ b/test/TestDummies/DummyLoggerConfigurationExtensions.cs
@@ -109,6 +109,14 @@ namespace TestDummies
                 s => new DummyWrappingSink(s),
                 wrappedSinkAction);
         }
-        
+
+        public static LoggerConfiguration WithDummyHardCodedString(
+            this LoggerDestructuringConfiguration loggerDestructuringConfiguration,
+            string hardCodedString
+        )
+        {
+            return loggerDestructuringConfiguration.With(new DummyHardCodedStringDestructuringPolicy(hardCodedString));
+        }
+
     }
 }


### PR DESCRIPTION
Fixes #115 

- Support method arguments of type `Type` by converting from the type's qualified name
- Add support for (non-extension) method `Destructure.AsScalar`
- Add test to check that custom extension methods `Destructure.XXX()` can properly be invoked
- Refactor `ConfigurationReader` by extracting all the *surrogate method* handling to a separate class 