### PR TITLE
fixes #111 - case-insensitive method argument-matching

### DIFF
--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -492,6 +492,30 @@ namespace Serilog.Settings.Configuration.Tests
             Assert.Equal(1, DummyRollingFileSink.Emitted.Count);
         }
 
+        [Trait("Bugfix", "#111")]
+        [Fact]
+        public void CaseInsensitiveArgumentNameMatching()
+        {
+            var json = @"{
+                ""Serilog"": {            
+                    ""Using"": [""TestDummies""],
+                    ""WriteTo"": [{
+                        ""Name"": ""DummyRollingFile"",
+                        ""Args"": {""PATHFORMAT"" : ""C:\\""}
+                    }]        
+                }
+            }";
+
+            var log = ConfigFromJson(json)
+                .CreateLogger();
+
+            DummyRollingFileSink.Emitted.Clear();
+
+            log.Write(Some.InformationEvent());
+
+            Assert.Equal(1, DummyRollingFileSink.Emitted.Count);
+        }
+
         [Trait("Bugfix", "#91")]
         [Fact]
         public void WriteToLoggerWithRestrictedToMinimumLevelIsSupported()


### PR DESCRIPTION
Per #111 method argument matching should be case-insensitive.

Note if there are questions or feedback, I am on vacation and won't be online again until Sept 5 earliest.