### PR TITLE
Add support and tests for more configuration methods

### DIFF
--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -374,7 +374,8 @@ namespace Serilog.Settings.Configuration
         internal static IList<MethodInfo> FindAuditSinkConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
         {
             var found = FindConfigurationExtensionMethods(configurationAssemblies, typeof(LoggerAuditSinkConfiguration));
-
+            if (configurationAssemblies.Contains(typeof(LoggerAuditSinkConfiguration).GetTypeInfo().Assembly))
+                found.AddRange(SurrogateConfigurationMethods.AuditTo);
             return found;
         }
 

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -362,7 +362,7 @@ namespace Serilog.Settings.Configuration
                 .FirstOrDefault();
         }
 
-        internal static IList<MethodInfo> FindSinkConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
+        static IList<MethodInfo> FindSinkConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
         {
             var found = FindConfigurationExtensionMethods(configurationAssemblies, typeof(LoggerSinkConfiguration));
             if (configurationAssemblies.Contains(typeof(LoggerSinkConfiguration).GetTypeInfo().Assembly))
@@ -371,7 +371,7 @@ namespace Serilog.Settings.Configuration
             return found;
         }
 
-        internal static IList<MethodInfo> FindAuditSinkConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
+        static IList<MethodInfo> FindAuditSinkConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
         {
             var found = FindConfigurationExtensionMethods(configurationAssemblies, typeof(LoggerAuditSinkConfiguration));
             if (configurationAssemblies.Contains(typeof(LoggerAuditSinkConfiguration).GetTypeInfo().Assembly))
@@ -379,7 +379,7 @@ namespace Serilog.Settings.Configuration
             return found;
         }
 
-        internal static IList<MethodInfo> FindFilterConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
+        static IList<MethodInfo> FindFilterConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
         {
             var found = FindConfigurationExtensionMethods(configurationAssemblies, typeof(LoggerFilterConfiguration));
             if (configurationAssemblies.Contains(typeof(LoggerFilterConfiguration).GetTypeInfo().Assembly))
@@ -388,7 +388,7 @@ namespace Serilog.Settings.Configuration
             return found;
         }
 
-        internal static IList<MethodInfo> FindDestructureConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
+        static IList<MethodInfo> FindDestructureConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
         {
             var found = FindConfigurationExtensionMethods(configurationAssemblies, typeof(LoggerDestructuringConfiguration));
             if (configurationAssemblies.Contains(typeof(LoggerDestructuringConfiguration).GetTypeInfo().Assembly))
@@ -397,7 +397,7 @@ namespace Serilog.Settings.Configuration
             return found;
         }
 
-        internal static IList<MethodInfo> FindEventEnricherConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
+        static IList<MethodInfo> FindEventEnricherConfigurationMethods(IReadOnlyCollection<Assembly> configurationAssemblies)
         {
             var found = FindConfigurationExtensionMethods(configurationAssemblies, typeof(LoggerEnrichmentConfiguration));
             if (configurationAssemblies.Contains(typeof(LoggerEnrichmentConfiguration).GetTypeInfo().Assembly))
@@ -406,7 +406,7 @@ namespace Serilog.Settings.Configuration
             return found;
         }
 
-        internal static List<MethodInfo> FindConfigurationExtensionMethods(IReadOnlyCollection<Assembly> configurationAssemblies, Type configType)
+        static List<MethodInfo> FindConfigurationExtensionMethods(IReadOnlyCollection<Assembly> configurationAssemblies, Type configType)
         {
             return configurationAssemblies
                 .SelectMany(a => a.ExportedTypes
@@ -423,7 +423,7 @@ namespace Serilog.Settings.Configuration
             return Regex.IsMatch(input, LevelSwitchNameRegex);
         }
 
-        internal static LogEventLevel ParseLogEventLevel(string value)
+        static LogEventLevel ParseLogEventLevel(string value)
         {
             if (!Enum.TryParse(value, out LogEventLevel parsedLevel))
                 throw new InvalidOperationException($"The value {value} is not a valid Serilog level.");

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/SurrogateConfigurationMethods.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/SurrogateConfigurationMethods.cs
@@ -32,10 +32,9 @@ namespace Serilog.Settings.Configuration
 
         /*
         Pass-through calls to various Serilog config methods which are
-        implemented as instance methods rather than extension methods. The
-        FindXXXConfigurationMethods calls (above) use these to add method
-        invocation expressions as surrogates so that SelectConfigurationMethod
-        has a way to match and invoke these instance methods.
+        implemented as instance methods rather than extension methods.
+        ConfigurationReader adds those to the already discovered extension methods
+        so they can be invoked as well.
         */
 
         // ReSharper disable UnusedMember.Local
@@ -49,9 +48,7 @@ namespace Serilog.Settings.Configuration
             ILogEventSink sink,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             LoggingLevelSwitch levelSwitch = null)
-        {
-            return loggerSinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
-        }
+            => loggerSinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
 
         static LoggerConfiguration Logger(
             LoggerSinkConfiguration loggerSinkConfiguration,
@@ -67,19 +64,19 @@ namespace Serilog.Settings.Configuration
             ILogEventSink sink,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             LoggingLevelSwitch levelSwitch = null)
-        {
-            return auditSinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
-        }
+            => auditSinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
 
         // .Filter...
         // =======
         // TODO: add overload for array argument (ILogEventEnricher[])
+        // expose `With(params ILogEventFilter[] filters)` as if it was `With(ILogEventFilter filter)`
         static LoggerConfiguration With(LoggerFilterConfiguration loggerFilterConfiguration, ILogEventFilter filter)
             => loggerFilterConfiguration.With(filter);
 
         // .Destructure...
         // ============
         // TODO: add overload for array argument (IDestructuringPolicy[])
+        // expose `With(params IDestructuringPolicy[] destructuringPolicies)` as if it was `With(IDestructuringPolicy policy)`
         static LoggerConfiguration With(LoggerDestructuringConfiguration loggerDestructuringConfiguration, IDestructuringPolicy policy)
             => loggerDestructuringConfiguration.With(policy);
 
@@ -97,13 +94,14 @@ namespace Serilog.Settings.Configuration
 
         // .Enrich...
         // =======
+        // expose `With(params ILogEventEnricher[] enrichers)` as if it was `With(ILogEventEnricher enricher)`
+        static LoggerConfiguration With(
+            LoggerEnrichmentConfiguration loggerEnrichmentConfiguration,
+            ILogEventEnricher enricher)
+            => loggerEnrichmentConfiguration.With(enricher);
+
         static LoggerConfiguration FromLogContext(LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
             => loggerEnrichmentConfiguration.FromLogContext();
-
-        static LoggerConfiguration With(LoggerEnrichmentConfiguration loggerEnrichmentConfiguration, ILogEventEnricher enricher)
-        {
-            return loggerEnrichmentConfiguration.With(enricher);
-        }
 
         // ReSharper restore UnusedMember.Local
     }

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/SurrogateConfigurationMethods.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/SurrogateConfigurationMethods.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq.Expressions;
+using System.Linq;
 using System.Reflection;
 using Serilog.Configuration;
 using Serilog.Core;
@@ -10,7 +10,7 @@ namespace Serilog.Settings.Configuration
 {
     /// <summary>
     /// Contains "fake extension" methods for the Serilog configuration API.
-    /// By default the settings knows how to find extension methods, but some configuration
+    /// By default the settings know how to find extension methods, but some configuration
     /// are actually "regular" method calls and would not be found otherwise.
     ///
     /// This static class contains internal methods that can be used instead.
@@ -18,54 +18,17 @@ namespace Serilog.Settings.Configuration
     /// </summary>
     static class SurrogateConfigurationMethods
     {
-        public static IEnumerable<MethodInfo> WriteTo
-        {
-            get
-            {
-                yield return GetSurrogateConfigurationMethod<LoggerSinkConfiguration, Action<LoggerConfiguration>, LoggingLevelSwitch>((c, a, s) => Logger(c, a, LevelAlias.Minimum, s));
-                yield return GetSurrogateConfigurationMethod<LoggerSinkConfiguration, ILogEventSink, LoggingLevelSwitch>((c, sink, s) => Sink(c, sink, LevelAlias.Minimum, s));
-            }
-        }
+        static readonly Dictionary<Type, MethodInfo[]> SurrogateMethodCandidates = typeof(SurrogateConfigurationMethods)
+            .GetTypeInfo().DeclaredMethods
+            .GroupBy(m => m.GetParameters().First().ParameterType)
+            .ToDictionary(g => g.Key, g => g.ToArray());
 
-        public static IEnumerable<MethodInfo> AuditTo
-        {
-            get
-            {
-                yield return GetSurrogateConfigurationMethod<LoggerAuditSinkConfiguration, ILogEventSink, LoggingLevelSwitch>((c, sink, s) => Sink(c, sink, LevelAlias.Minimum, s));
-            }
-        }
 
-        public static IEnumerable<MethodInfo> Filter
-        {
-            get
-            {
-                yield return GetSurrogateConfigurationMethod<LoggerFilterConfiguration, ILogEventFilter, object>((c, f, _) => With(c, f));
-            }
-        }
-
-        public static IEnumerable<MethodInfo> Destructure
-        {
-            get
-            {
-                yield return GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, IDestructuringPolicy, object>((c, d, _) => With(c, d));
-                yield return GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, int, object>((c, m, _) => ToMaximumDepth(c, m));
-                yield return GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, int, object>((c, m, _) => ToMaximumStringLength(c, m));
-                yield return GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, int, object>((c, m, _) => ToMaximumCollectionCount(c, m));
-                yield return GetSurrogateConfigurationMethod<LoggerDestructuringConfiguration, Type, object>((c, t, _) => AsScalar(c, t));
-            }
-        }
-
-        public static IEnumerable<MethodInfo> Enrich
-        {
-            get
-            {
-                yield return GetSurrogateConfigurationMethod<LoggerEnrichmentConfiguration, object, object>((c, _, __) => FromLogContext(c));
-                yield return GetSurrogateConfigurationMethod<LoggerEnrichmentConfiguration, ILogEventEnricher, object>((c, e, __) => With(c, e));
-            }
-        }
-
-        static MethodInfo GetSurrogateConfigurationMethod<TConfiguration, TArg1, TArg2>(Expression<Action<TConfiguration, TArg1, TArg2>> method)
-            => (method.Body as MethodCallExpression)?.Method;
+        internal static readonly MethodInfo[] WriteTo = SurrogateMethodCandidates[typeof(LoggerSinkConfiguration)];
+        internal static readonly MethodInfo[] AuditTo = SurrogateMethodCandidates[typeof(LoggerAuditSinkConfiguration)];
+        internal static readonly MethodInfo[] Enrich = SurrogateMethodCandidates[typeof(LoggerEnrichmentConfiguration)];
+        internal static readonly MethodInfo[] Destructure = SurrogateMethodCandidates[typeof(LoggerDestructuringConfiguration)];
+        internal static readonly MethodInfo[] Filter = SurrogateMethodCandidates[typeof(LoggerFilterConfiguration)];
 
         /*
         Pass-through calls to various Serilog config methods which are
@@ -74,6 +37,10 @@ namespace Serilog.Settings.Configuration
         invocation expressions as surrogates so that SelectConfigurationMethod
         has a way to match and invoke these instance methods.
         */
+
+        // ReSharper disable UnusedMember.Local
+        // those methods are discovered through reflection by `SurrogateMethodCandidates`
+        // ReSharper has no way to see that they are actually used ...
 
         // .WriteTo...
         // ========
@@ -138,5 +105,6 @@ namespace Serilog.Settings.Configuration
             return loggerEnrichmentConfiguration.With(enricher);
         }
 
+        // ReSharper restore UnusedMember.Local
     }
 }

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/SurrogateConfigurationMethods.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/SurrogateConfigurationMethods.cs
@@ -23,6 +23,7 @@ namespace Serilog.Settings.Configuration
             get
             {
                 yield return GetSurrogateConfigurationMethod<LoggerSinkConfiguration, Action<LoggerConfiguration>, LoggingLevelSwitch>((c, a, s) => Logger(c, a, LevelAlias.Minimum, s));
+                yield return GetSurrogateConfigurationMethod<LoggerSinkConfiguration, ILogEventSink, LoggingLevelSwitch>((c, sink, s) => Sink(c, sink, LevelAlias.Minimum, s));
             }
         }
 
@@ -64,6 +65,15 @@ namespace Serilog.Settings.Configuration
         invocation expressions as surrogates so that SelectConfigurationMethod
         has a way to match and invoke these instance methods.
         */
+
+        internal static LoggerConfiguration Sink(
+            LoggerSinkConfiguration loggerSinkConfiguration,
+            ILogEventSink sink,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null)
+        {
+            return loggerSinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
+        }
 
         // TODO: add overload for array argument (ILogEventEnricher[])
         static LoggerConfiguration With(LoggerFilterConfiguration loggerFilterConfiguration, ILogEventFilter filter)

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/SurrogateConfigurationMethods.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/SurrogateConfigurationMethods.cs
@@ -27,6 +27,14 @@ namespace Serilog.Settings.Configuration
             }
         }
 
+        public static IEnumerable<MethodInfo> AuditTo
+        {
+            get
+            {
+                yield return GetSurrogateConfigurationMethod<LoggerAuditSinkConfiguration, ILogEventSink, LoggingLevelSwitch>((c, sink, s) => Sink(c, sink, LevelAlias.Minimum, s));
+            }
+        }
+
         public static IEnumerable<MethodInfo> Filter
         {
             get
@@ -66,7 +74,9 @@ namespace Serilog.Settings.Configuration
         has a way to match and invoke these instance methods.
         */
 
-        internal static LoggerConfiguration Sink(
+        // .WriteTo...
+        // ========
+        static LoggerConfiguration Sink(
             LoggerSinkConfiguration loggerSinkConfiguration,
             ILogEventSink sink,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
@@ -75,10 +85,32 @@ namespace Serilog.Settings.Configuration
             return loggerSinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
         }
 
+        static LoggerConfiguration Logger(
+            LoggerSinkConfiguration loggerSinkConfiguration,
+            Action<LoggerConfiguration> configureLogger,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null)
+            => loggerSinkConfiguration.Logger(configureLogger, restrictedToMinimumLevel, levelSwitch);
+
+        // .AuditTo...
+        // ========
+        static LoggerConfiguration Sink(
+            LoggerAuditSinkConfiguration auditSinkConfiguration,
+            ILogEventSink sink,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null)
+        {
+            return auditSinkConfiguration.Sink(sink, restrictedToMinimumLevel, levelSwitch);
+        }
+
+        // .Filter...
+        // =======
         // TODO: add overload for array argument (ILogEventEnricher[])
         static LoggerConfiguration With(LoggerFilterConfiguration loggerFilterConfiguration, ILogEventFilter filter)
             => loggerFilterConfiguration.With(filter);
 
+        // .Destructure...
+        // ============
         // TODO: add overload for array argument (IDestructuringPolicy[])
         static LoggerConfiguration With(LoggerDestructuringConfiguration loggerDestructuringConfiguration, IDestructuringPolicy policy)
             => loggerDestructuringConfiguration.With(policy);
@@ -95,15 +127,10 @@ namespace Serilog.Settings.Configuration
         static LoggerConfiguration AsScalar(LoggerDestructuringConfiguration loggerDestructuringConfiguration, Type scalarType)
             => loggerDestructuringConfiguration.AsScalar(scalarType);
 
+        // .Enrich...
+        // =======
         static LoggerConfiguration FromLogContext(LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
             => loggerEnrichmentConfiguration.FromLogContext();
 
-        // Unlike the other configuration methods, Logger is an instance method rather than an extension.
-        static LoggerConfiguration Logger(
-            LoggerSinkConfiguration loggerSinkConfiguration,
-            Action<LoggerConfiguration> configureLogger,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
-            LoggingLevelSwitch levelSwitch = null)
-            => loggerSinkConfiguration.Logger(configureLogger, restrictedToMinimumLevel, levelSwitch);
     }
 }

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/SurrogateConfigurationMethods.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/SurrogateConfigurationMethods.cs
@@ -60,6 +60,7 @@ namespace Serilog.Settings.Configuration
             get
             {
                 yield return GetSurrogateConfigurationMethod<LoggerEnrichmentConfiguration, object, object>((c, _, __) => FromLogContext(c));
+                yield return GetSurrogateConfigurationMethod<LoggerEnrichmentConfiguration, ILogEventEnricher, object>((c, e, __) => With(c, e));
             }
         }
 
@@ -131,6 +132,11 @@ namespace Serilog.Settings.Configuration
         // =======
         static LoggerConfiguration FromLogContext(LoggerEnrichmentConfiguration loggerEnrichmentConfiguration)
             => loggerEnrichmentConfiguration.FromLogContext();
+
+        static LoggerConfiguration With(LoggerEnrichmentConfiguration loggerEnrichmentConfiguration, ILogEventEnricher enricher)
+        {
+            return loggerEnrichmentConfiguration.With(enricher);
+        }
 
     }
 }

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.Extensions.Configuration;
 using Serilog.Core;
 using Serilog.Events;
@@ -118,8 +118,8 @@ namespace Serilog.Settings.Configuration.Tests
             var log = ConfigFromJson(json)
                 .CreateLogger();
 
-            DummyRollingFileSink.Emitted.Clear();
-            DummyRollingFileAuditSink.Emitted.Clear();
+            DummyRollingFileSink.Reset();
+            DummyRollingFileAuditSink.Reset();
 
             log.Write(Some.InformationEvent());
 
@@ -143,8 +143,8 @@ namespace Serilog.Settings.Configuration.Tests
             var log = ConfigFromJson(json)
                 .CreateLogger();
 
-            DummyRollingFileSink.Emitted.Clear();
-            DummyRollingFileAuditSink.Emitted.Clear();
+            DummyRollingFileSink.Reset();
+            DummyRollingFileAuditSink.Reset();
 
             log.Write(Some.InformationEvent());
 
@@ -438,7 +438,7 @@ namespace Serilog.Settings.Configuration.Tests
             var log = ConfigFromJson(json)
                 .CreateLogger();
 
-            DummyRollingFileSink.Emitted.Clear();
+            DummyRollingFileSink.Reset();
 
             log.Write(Some.InformationEvent());
 
@@ -462,7 +462,7 @@ namespace Serilog.Settings.Configuration.Tests
             var log = ConfigFromJson(json)
                 .CreateLogger();
 
-            DummyRollingFileSink.Emitted.Clear();
+            DummyRollingFileSink.Reset();
 
             log.Write(Some.InformationEvent());
 
@@ -486,7 +486,7 @@ namespace Serilog.Settings.Configuration.Tests
             var log = ConfigFromJson(json)
                 .CreateLogger();
 
-            DummyRollingFileSink.Emitted.Clear();
+            DummyRollingFileSink.Reset();
 
             log.Write(Some.InformationEvent());
 
@@ -510,7 +510,7 @@ namespace Serilog.Settings.Configuration.Tests
             var log = ConfigFromJson(json)
                 .CreateLogger();
 
-            DummyRollingFileSink.Emitted.Clear();
+            DummyRollingFileSink.Reset();
 
             log.Write(Some.InformationEvent());
 
@@ -534,7 +534,7 @@ namespace Serilog.Settings.Configuration.Tests
             var log = ConfigFromJson(json)
                 .CreateLogger();
 
-            DummyRollingFileSink.Emitted.Clear();
+            DummyRollingFileSink.Reset();
 
             log.Write(Some.InformationEvent());
 
@@ -565,7 +565,7 @@ namespace Serilog.Settings.Configuration.Tests
             var log = ConfigFromJson(json)
             .CreateLogger();
 
-            DummyRollingFileSink.Emitted.Clear();
+            DummyRollingFileSink.Reset();
 
             log.Write(Some.InformationEvent());
             log.Write(Some.WarningEvent());
@@ -598,9 +598,9 @@ namespace Serilog.Settings.Configuration.Tests
             }";
 
             var log = ConfigFromJson(json)
-            .CreateLogger();
+                .CreateLogger();
 
-            DummyRollingFileSink.Emitted.Clear();
+            DummyRollingFileSink.Reset();
 
             log.Write(Some.InformationEvent());
             log.Write(Some.WarningEvent());
@@ -771,7 +771,7 @@ namespace Serilog.Settings.Configuration.Tests
                 .WriteTo.Sink(new DelegatingSink(e => evt = e))
                 .CreateLogger();
 
-            log.Information("Destructuring as scalar {@Scalarized}", new Version(2,3));
+            log.Information("Destructuring as scalar {@Scalarized}", new Version(2, 3));
             var prop = evt.Properties["Scalarized"];
 
             Assert.IsType<ScalarValue>(prop);
@@ -795,7 +795,7 @@ namespace Serilog.Settings.Configuration.Tests
                 .WriteTo.Sink(new DelegatingSink(e => evt = e))
                 .CreateLogger();
 
-            log.Information("Destructuring as scalar {@Scalarized}", new Version(2,3));
+            log.Information("Destructuring as scalar {@Scalarized}", new Version(2, 3));
             var prop = evt.Properties["Scalarized"];
 
             Assert.IsType<ScalarValue>(prop);

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -801,7 +801,6 @@ namespace Serilog.Settings.Configuration.Tests
             Assert.IsType<ScalarValue>(prop);
         }
 
-
         [Fact]
         public void WriteToSinkIsAppliedWithCustomSink()
         {
@@ -882,7 +881,6 @@ namespace Serilog.Settings.Configuration.Tests
             Assert.Single(DummyRollingFileSink.Emitted);
         }
 
-        
         [Fact]
         public void AuditToSinkIsAppliedWithCustomSink()
         {
@@ -963,7 +961,6 @@ namespace Serilog.Settings.Configuration.Tests
             Assert.Single(DummyRollingFileSink.Emitted);
         }
 
-        
         [Fact]
         public void EnrichWithIsAppliedWithCustomEnricher()
         {

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Microsoft.Extensions.Configuration;
 using Serilog.Core;
 using Serilog.Events;
@@ -799,6 +799,87 @@ namespace Serilog.Settings.Configuration.Tests
             var prop = evt.Properties["Scalarized"];
 
             Assert.IsType<ScalarValue>(prop);
+        }
+
+
+        [Fact]
+        public void WriteToSinkIsAppliedWithCustomSink()
+        {
+            var json = $@"{{
+                ""Serilog"": {{
+                    ""Using"": [""TestDummies""],
+                    ""WriteTo"": [
+                    {{
+                        ""Name"": ""Sink"",
+                        ""Args"": {{
+                            ""sink"": ""{typeof(DummyRollingFileSink).AssemblyQualifiedName}""
+                        }}
+                    }}]
+                }}
+            }}";
+
+            var log = ConfigFromJson(json)
+                .CreateLogger();
+
+            DummyRollingFileSink.Reset();
+            log.Write(Some.InformationEvent());
+
+            Assert.Single(DummyRollingFileSink.Emitted);
+        }
+
+        [Fact]
+        public void WriteToSinkIsAppliedWithCustomSinkAndMinimumLevel()
+        {
+            var json = $@"{{
+                ""Serilog"": {{
+                    ""Using"": [""TestDummies""],
+                    ""WriteTo"": [
+                    {{
+                        ""Name"": ""Sink"",
+                        ""Args"": {{
+                            ""sink"": ""{typeof(DummyRollingFileSink).AssemblyQualifiedName}"",
+                            ""restrictedToMinimumLevel"": ""Warning""
+                        }}
+                    }}]
+                }}
+            }}";
+
+            var log = ConfigFromJson(json)
+                .CreateLogger();
+
+            DummyRollingFileSink.Reset();
+            log.Write(Some.InformationEvent());
+            log.Write(Some.WarningEvent());
+
+            Assert.Single(DummyRollingFileSink.Emitted);
+        }
+
+        [Fact]
+        public void WriteToSinkIsAppliedWithCustomSinkAndLevelSwitch()
+        {
+            var json = $@"{{
+                ""Serilog"": {{
+                    ""Using"": [""TestDummies""],
+                    ""LevelSwitches"": {{""$switch1"": ""Warning"" }},
+                    ""WriteTo"": [
+                    {{
+                        ""Name"": ""Sink"",
+                        ""Args"": {{
+                            ""sink"": ""{typeof(DummyRollingFileSink).AssemblyQualifiedName}"",
+                            ""levelSwitch"": ""$switch1""
+                        }}
+                    }}]
+                }}
+            }}";
+
+            var log = ConfigFromJson(json)
+                .CreateLogger();
+
+            DummyRollingFileSink.Reset();
+            log.Write(Some.InformationEvent());
+            log.Write(Some.WarningEvent());
+
+            Assert.Single(DummyRollingFileSink.Emitted);
         }
     }
 }

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -991,5 +991,33 @@ namespace Serilog.Settings.Configuration.Tests
             Assert.NotNull(evt);
             Assert.True(evt.Properties.ContainsKey("ThreadId"), "Event should have enriched property ThreadId");
         }
+
+        [Fact]
+        public void FilterWithIsAppliedWithCustomFilter()
+        {
+            LogEvent evt = null;
+
+            var json = $@"{{
+                ""Serilog"": {{
+                    ""Using"": [""TestDummies""],
+                    ""Filter"": [
+                    {{
+                        ""Name"": ""With"",
+                        ""Args"": {{
+                            ""filter"": ""{typeof(DummyAnonymousUserFilter).AssemblyQualifiedName}""
+                        }}
+                    }}]
+                }}
+            }}";
+
+            var log = ConfigFromJson(json)
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.ForContext("User", "anonymous").Write(Some.InformationEvent());
+            Assert.Null(evt);
+            log.ForContext("User", "the user").Write(Some.InformationEvent());
+            Assert.NotNull(evt);
+        }
     }
 }

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -962,5 +962,34 @@ namespace Serilog.Settings.Configuration.Tests
 
             Assert.Single(DummyRollingFileSink.Emitted);
         }
+
+        
+        [Fact]
+        public void EnrichWithIsAppliedWithCustomEnricher()
+        {
+            LogEvent evt = null;
+
+            var json = $@"{{
+                ""Serilog"": {{
+                    ""Using"": [""TestDummies""],
+                    ""Enrich"": [
+                    {{
+                        ""Name"": ""With"",
+                        ""Args"": {{
+                            ""enricher"": ""{typeof(DummyThreadIdEnricher).AssemblyQualifiedName}""
+                        }}
+                    }}]
+                }}
+            }}";
+
+            var log = ConfigFromJson(json)
+                .WriteTo.Sink(new DelegatingSink(e => evt = e))
+                .CreateLogger();
+
+            log.Write(Some.InformationEvent());
+
+            Assert.NotNull(evt);
+            Assert.True(evt.Properties.ContainsKey("ThreadId"), "Event should have enriched property ThreadId");
+        }
     }
 }

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -881,5 +881,86 @@ namespace Serilog.Settings.Configuration.Tests
 
             Assert.Single(DummyRollingFileSink.Emitted);
         }
+
+        
+        [Fact]
+        public void AuditToSinkIsAppliedWithCustomSink()
+        {
+            var json = $@"{{
+                ""Serilog"": {{
+                    ""Using"": [""TestDummies""],
+                    ""AuditTo"": [
+                    {{
+                        ""Name"": ""Sink"",
+                        ""Args"": {{
+                            ""sink"": ""{typeof(DummyRollingFileSink).AssemblyQualifiedName}""
+                        }}
+                    }}]
+                }}
+            }}";
+
+            var log = ConfigFromJson(json)
+                .CreateLogger();
+
+            DummyRollingFileSink.Reset();
+            log.Write(Some.InformationEvent());
+
+            Assert.Single(DummyRollingFileSink.Emitted);
+        }
+
+        [Fact]
+        public void AuditToSinkIsAppliedWithCustomSinkAndMinimumLevel()
+        {
+            var json = $@"{{
+                ""Serilog"": {{
+                    ""Using"": [""TestDummies""],
+                    ""AuditTo"": [
+                    {{
+                        ""Name"": ""Sink"",
+                        ""Args"": {{
+                            ""sink"": ""{typeof(DummyRollingFileSink).AssemblyQualifiedName}"",
+                            ""restrictedToMinimumLevel"": ""Warning""
+                        }}
+                    }}]
+                }}
+            }}";
+
+            var log = ConfigFromJson(json)
+                .CreateLogger();
+
+            DummyRollingFileSink.Reset();
+            log.Write(Some.InformationEvent());
+            log.Write(Some.WarningEvent());
+
+            Assert.Single(DummyRollingFileSink.Emitted);
+        }
+
+        [Fact]
+        public void AuditToSinkIsAppliedWithCustomSinkAndLevelSwitch()
+        {
+            var json = $@"{{
+                ""Serilog"": {{
+                    ""Using"": [""TestDummies""],
+                    ""LevelSwitches"": {{""$switch1"": ""Warning"" }},
+                    ""AuditTo"": [
+                    {{
+                        ""Name"": ""Sink"",
+                        ""Args"": {{
+                            ""sink"": ""{typeof(DummyRollingFileSink).AssemblyQualifiedName}"",
+                            ""levelSwitch"": ""$switch1""
+                        }}
+                    }}]
+                }}
+            }}";
+
+            var log = ConfigFromJson(json)
+                .CreateLogger();
+
+            DummyRollingFileSink.Reset();
+            log.Write(Some.InformationEvent());
+            log.Write(Some.WarningEvent());
+
+            Assert.Single(DummyRollingFileSink.Emitted);
+        }
     }
 }

--- a/test/TestDummies/DummyAnonymousUserFilter.cs
+++ b/test/TestDummies/DummyAnonymousUserFilter.cs
@@ -1,0 +1,25 @@
+﻿
+using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies
+{
+    public class DummyAnonymousUserFilter : ILogEventFilter
+    {
+        public bool IsEnabled(LogEvent logEvent)
+        {
+            if (logEvent.Properties.ContainsKey("User"))
+            {
+                if (logEvent.Properties["User"] is ScalarValue sv)
+                {
+                    if (sv.Value is string s && s == "anonymous")
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/test/TestDummies/DummyRollingFileAuditSink.cs
+++ b/test/TestDummies/DummyRollingFileAuditSink.cs
@@ -8,13 +8,18 @@ namespace TestDummies
     public class DummyRollingFileAuditSink : ILogEventSink
     {
         [ThreadStatic]
-        // ReSharper disable ThreadStaticFieldHasInitializer
-        public static List<LogEvent> Emitted = new List<LogEvent>();
-        // ReSharper restore ThreadStaticFieldHasInitializer
+        static List<LogEvent> _emitted;
+
+        public static List<LogEvent> Emitted => _emitted ?? (_emitted = new List<LogEvent>());
 
         public void Emit(LogEvent logEvent)
         {
             Emitted.Add(logEvent);
+        }
+
+        public static void Reset()
+        {
+            _emitted = null;
         }
     }
 }

--- a/test/TestDummies/DummyRollingFileSink.cs
+++ b/test/TestDummies/DummyRollingFileSink.cs
@@ -8,13 +8,18 @@ namespace TestDummies
     public class DummyRollingFileSink : ILogEventSink
     {
         [ThreadStatic]
-        // ReSharper disable ThreadStaticFieldHasInitializer
-        public static List<LogEvent> Emitted = new List<LogEvent>();
-        // ReSharper restore ThreadStaticFieldHasInitializer
+        static List<LogEvent> _emitted;
+
+        public static List<LogEvent> Emitted => _emitted ?? (_emitted = new List<LogEvent>());
 
         public void Emit(LogEvent logEvent)
         {
             Emitted.Add(logEvent);
+        }
+
+        public static void Reset()
+        {
+            _emitted = null;
         }
     }
 }

--- a/test/TestDummies/DummyThreadIdEnricher.cs
+++ b/test/TestDummies/DummyThreadIdEnricher.cs
@@ -6,7 +6,9 @@ namespace TestDummies
     public class DummyThreadIdEnricher : ILogEventEnricher
     {
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
-        {          
+        {
+            logEvent.AddPropertyIfAbsent(propertyFactory
+                .CreateProperty("ThreadId", "SomeId"));
         }
     }
 }

--- a/test/TestDummies/DummyWrappingSink.cs
+++ b/test/TestDummies/DummyWrappingSink.cs
@@ -8,11 +8,11 @@ namespace TestDummies
     public class DummyWrappingSink : ILogEventSink
     {
         [ThreadStatic]
-        // ReSharper disable ThreadStaticFieldHasInitializer
-        public static List<LogEvent> Emitted = new List<LogEvent>();
-        // ReSharper restore ThreadStaticFieldHasInitializer
+        static List<LogEvent> _emitted;
 
-        private readonly ILogEventSink _sink;
+        public static List<LogEvent> Emitted => _emitted ?? (_emitted = new List<LogEvent>());
+
+        readonly ILogEventSink _sink;
 
         public DummyWrappingSink(ILogEventSink sink)
         {
@@ -23,6 +23,11 @@ namespace TestDummies
         {
             Emitted.Add(logEvent);
             _sink.Emit(logEvent);
+        }
+
+        public static void Reset()
+        {
+            _emitted = null;
         }
     }
 }


### PR DESCRIPTION
fixes #121 (similar to the work done in the core repo in serilog/serilog#1194 )

It adds support and tests for : 
- `WriteTo.Sink(ILogEventSink logEventSink, LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum, LoggingLevelSwitch levelSwitch = null)`
- `AuditTo.Sink(ILogEventSink logEventSink, LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum, LoggingLevelSwitch levelSwitch = null)`
- `Enrich.With(params ILogEventEnricher[] enrichers)` (with surrogate `Enrich.With(ILogEventEnricher enricher)` )
- `Filter.With(params ILogEventFilter[] filters)` (with surrogate `Enrich.With(ILogEventFilter filter)` ) - _this one was already supported, but I added a unit test_

I also refactored a bit the part about *surrogate* configuration methods. There is now less code, and it is more similar to the equivalent code in the core Serilog repo.
