### PR TITLE
[WIP] Failing test for #142

### DIFF
--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -425,7 +425,7 @@ namespace Serilog.Settings.Configuration.Tests
                 ""Serilog"": {            
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [{
-                        ""Name"": ""DummyRollingFile"",
+                        ""Name"": ""DummyWithConfiguration"",
                         ""Args"": {""pathFormat"" : ""C:\\"",
                                    ""configurationSection"" : { ""foo"" : ""bar"" } }
                     }]        
@@ -435,14 +435,17 @@ namespace Serilog.Settings.Configuration.Tests
             // IConfiguration and IConfigurationSection arguments do not have
             // default values so they will throw if they are not populated
 
+
+            DummyConfigurationSink.Reset();
             var log = ConfigFromJson(json)
                 .CreateLogger();
 
-            DummyRollingFileSink.Reset();
 
             log.Write(Some.InformationEvent());
 
-            Assert.Equal(1, DummyRollingFileSink.Emitted.Count);
+            Assert.NotNull(DummyConfigurationSink.Configuration);
+            Assert.NotNull(DummyConfigurationSink.ConfigSection);
+            Assert.Equal("bar", DummyConfigurationSink.ConfigSection["foo"]);
         }
 
         [Fact]

--- a/test/TestDummies/DummyConfigurationSink.cs
+++ b/test/TestDummies/DummyConfigurationSink.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies
+{
+    public class DummyConfigurationSink : ILogEventSink
+    {
+        [ThreadStatic]
+        static List<LogEvent> _emitted;
+
+        [ThreadStatic]
+        static IConfiguration _configuration;
+
+        [ThreadStatic]
+        static IConfigurationSection _configSection;
+
+        public static List<LogEvent> Emitted => _emitted ?? (_emitted = new List<LogEvent>());
+
+        public static IConfiguration Configuration => _configuration;
+
+        public static IConfigurationSection ConfigSection => _configSection;
+
+
+        public DummyConfigurationSink(IConfiguration configuration, IConfigurationSection configSection)
+        {
+            _configuration = configuration;
+            _configSection = configSection;
+        }
+
+        public void Emit(LogEvent logEvent)
+        {
+            Emitted.Add(logEvent);
+        }
+
+        public static void Reset()
+        {
+            _emitted = null;
+            _configuration = null;
+            _configSection = null;
+        }
+
+    }
+}

--- a/test/TestDummies/DummyLoggerConfigurationExtensions.cs
+++ b/test/TestDummies/DummyLoggerConfigurationExtensions.cs
@@ -37,14 +37,14 @@ namespace TestDummies
             return loggerSinkConfiguration.Sink(new DummyRollingFileSink(), restrictedToMinimumLevel);
         }
 
-        public static LoggerConfiguration DummyRollingFile(
+        public static LoggerConfiguration DummyWithConfiguration(
             this LoggerSinkConfiguration loggerSinkConfiguration,
             IConfiguration appConfiguration,
             IConfigurationSection configurationSection,
             string pathFormat,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
         {
-            return loggerSinkConfiguration.Sink(new DummyRollingFileSink(), restrictedToMinimumLevel);
+            return loggerSinkConfiguration.Sink(new DummyConfigurationSink(appConfiguration, configurationSection), restrictedToMinimumLevel);
         }
 
         public static LoggerConfiguration DummyRollingFile(


### PR DESCRIPTION
Trying to figure out the bug #142 by adding a failing test.

Given a sink configuration method like : 

```csharp
public static LoggerConfiguration DummyWithConfiguration(
	this LoggerSinkConfiguration loggerSinkConfiguration,
	IConfiguration appConfiguration,
	IConfigurationSection configurationSection,
	string pathFormat,
	LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum)
{
	return loggerSinkConfiguration.Sink(new DummyConfigurationSink(appConfiguration, configurationSection), restrictedToMinimumLevel);
}
```

This test fails (at the first assertion) : 

```csharp
[Fact]
public void SinkWithIConfigurationArguments()
{
	var json = @"{
		""Serilog"": {            
			""Using"": [""TestDummies""],
			""WriteTo"": [{
				""Name"": ""DummyWithConfiguration"",
				""Args"": {""pathFormat"" : ""C:\\"",
						   ""configurationSection"" : { ""foo"" : ""bar"" } }
			}]        
		}
	}";

	// IConfiguration and IConfigurationSection arguments do not have
	// default values so they will throw if they are not populated


	DummyConfigurationSink.Reset();
	var log = ConfigFromJson(json)
		.CreateLogger();


	log.Write(Some.InformationEvent());

	Assert.NotNull(DummyConfigurationSink.Configuration);
	Assert.NotNull(DummyConfigurationSink.ConfigSection);
	Assert.Equal("bar", DummyConfigurationSink.ConfigSection["foo"]);
}
```

First I want to be sure that this test should pass, and I understand how the `IConfiguration`/`IConfigurationSection` support works. 

@MV10 if you come by, do you agree with me that such a test should pass ? Thanks !