### PR TITLE
No longer throw when calling a method with optional IConfiguration param

### DIFF
--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -331,7 +331,7 @@ namespace Serilog.Settings.Configuration
                                 select directive.Key == null ? p.DefaultValue : directive.Value.ConvertTo(p.ParameterType, declaredLevelSwitches)).ToList();
 
                     var parm = methodInfo.GetParameters().FirstOrDefault(i => i.ParameterType == typeof(IConfiguration));
-                    if (parm != null)
+                    if (parm != null && !parm.HasDefaultValue)
                     {
                         if (_configuration is null)
                         {

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -462,7 +462,8 @@ namespace Serilog.Settings.Configuration.Tests
 
             log.Write(Some.InformationEvent());
 
-            Assert.NotNull(DummyConfigurationSink.Configuration);
+            // null is the default value
+            Assert.Null(DummyConfigurationSink.Configuration);
         }
         
         [Fact]

--- a/test/Serilog.Settings.Configuration.Tests/LoggerConfigurationExtensionsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/LoggerConfigurationExtensionsTests.cs
@@ -55,8 +55,7 @@ namespace Serilog.Settings.Configuration.Tests
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [{
                         ""Name"": ""DummyWithConfiguration"",
-                        ""Args"": {""pathFormat"" : ""C:\\"",
-                                   ""configurationSection"" : { ""foo"" : ""bar"" } }
+                        ""Args"": {}
                     }]        
                 }
             }";
@@ -74,6 +73,31 @@ namespace Serilog.Settings.Configuration.Tests
                          "This is not supported when only a `IConfigSection` has been provided. " +
                          "(method 'Serilog.LoggerConfiguration DummyWithConfiguration(Serilog.Configuration.LoggerSinkConfiguration, Microsoft.Extensions.Configuration.IConfiguration, Microsoft.Extensions.Configuration.IConfigurationSection, System.String, Serilog.Events.LogEventLevel)')",
                 exception.Message);
+
+        }
+
+        [Fact]
+        [Trait("BugFix", "https://github.com/serilog/serilog-settings-configuration/issues/143")]
+        public void ReadFromConfigurationSectionDoesNotThrowWhenTryingToCallConfigurationMethodWithOptionalIConfigurationParam()
+        {
+            var json = @"{
+                ""NotSerilog"": {            
+                    ""Using"": [""TestDummies""],
+                    ""WriteTo"": [{
+                        ""Name"": ""DummyWithOptionalConfiguration"",
+                        ""Args"": {}
+                    }]        
+                }
+            }";
+
+            var config = new ConfigurationBuilder()
+                .AddJsonString(json)
+                .Build();
+
+            // this should not throw because DummyWithOptionalConfiguration accepts an optional config
+            new LoggerConfiguration()
+                .ReadFrom.ConfigurationSection(config.GetSection("NotSerilog"))
+                .CreateLogger();
 
         }
     }


### PR DESCRIPTION
In that case, the default value of the param will be passed

This PR completed the parts I missed in https://github.com/serilog/serilog-settings-configuration/pull/144 

Based on comment https://github.com/serilog/serilog-settings-configuration/issues/148#issuecomment-430221384 by @MV10 , an edge case was not tested ... it is now covered and fixed ! 

