### PR TITLE
Update Nuget package license format to new format

### DIFF
--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Microsoft.Extensions.Configuration (appsettings.json) support for Serilog.</Description>
@@ -15,7 +15,7 @@
     <PackageTags>serilog;json</PackageTags>
     <PackageIconUrl>https://serilog.net/images/serilog-configuration-nuget.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/serilog/serilog-settings-configuration</PackageProjectUrl>
-    <PackageLicenseUrl>https://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
+    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/serilog/serilog-settings-configuration</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <RootNamespace>Serilog</RootNamespace>


### PR DESCRIPTION
`licenseUrl` is now deprecated so we use a `license expression`

Tracked in https://github.com/serilog/serilog/issues/1265


This properly populate the license information in the nuget package : 

![image](https://user-images.githubusercontent.com/160544/50703938-ffb7a200-1055-11e9-9c63-3805c1a4cec0.png)
