### PR TITLE
DllScanningAssemblyFinder fixes (#157, #150, #122, #156)

### DIFF
--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Microsoft.Extensions.Configuration (appsettings.json) support for Serilog.</Description>
@@ -19,6 +19,10 @@
     <RepositoryUrl>https://github.com/serilog/serilog-settings-configuration</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <RootNamespace>Serilog</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="('$(TargetFramework)' == 'net451') Or ('$(TargetFramework)' == 'net461')">
+    <DefineConstants>$(DefineConstants);PRIVATE_BIN</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/Assemblies/DllScanningAssemblyFinder.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/Assemblies/DllScanningAssemblyFinder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 
@@ -9,12 +10,57 @@ namespace Serilog.Settings.Configuration.Assemblies
     {
         public override IReadOnlyList<AssemblyName> FindAssembliesContainingName(string nameToFind)
         {
-            var query = from outputAssemblyPath in System.IO.Directory.GetFiles(AppDomain.CurrentDomain.BaseDirectory, "*.dll")
-                let assemblyFileName = System.IO.Path.GetFileNameWithoutExtension(outputAssemblyPath)
-                where IsCaseInsensitiveMatch(assemblyFileName, nameToFind)
-                select AssemblyName.GetAssemblyName(outputAssemblyPath);
+            var probeDirs = new List<string>();
+            
+            if (!string.IsNullOrEmpty(AppDomain.CurrentDomain.BaseDirectory))
+            {
+                probeDirs.Add(AppDomain.CurrentDomain.BaseDirectory);
+
+#if PRIVATE_BIN
+                var privateBinPath = AppDomain.CurrentDomain.SetupInformation.PrivateBinPath;
+                if (!string.IsNullOrEmpty(privateBinPath))
+                {
+                    foreach (var path in privateBinPath.Split(';'))
+                    {
+                        if (Path.IsPathRooted(path))
+                        {
+                            probeDirs.Add(path);
+                        }
+                        else
+                        {
+                            probeDirs.Add(Path.Combine(AppDomain.CurrentDomain.BaseDirectory, path));
+                        }
+                    }
+                }
+#endif
+            }
+            else
+            {
+                probeDirs.Add(Path.GetDirectoryName(typeof(AssemblyFinder).Assembly.Location));
+            }
+
+            var query = from probeDir in probeDirs
+                        where Directory.Exists(probeDir)
+                        from outputAssemblyPath in Directory.GetFiles(probeDir, "*.dll")
+                        let assemblyFileName = Path.GetFileNameWithoutExtension(outputAssemblyPath)
+                        where IsCaseInsensitiveMatch(assemblyFileName, nameToFind)
+                        let assemblyName = TryGetAssemblyNameFrom(outputAssemblyPath)
+                        where assemblyName != null
+                        select assemblyName;
 
             return query.ToList().AsReadOnly();
+
+            AssemblyName TryGetAssemblyNameFrom(string path)
+            {
+                try
+                {
+                    return AssemblyName.GetAssemblyName(path);
+                }
+                catch (BadImageFormatException)
+                {
+                    return null;
+                }
+            }
         }
     }
 }

--- a/test/Serilog.Settings.Configuration.Tests/DllScanningAssemblyFinderTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/DllScanningAssemblyFinderTests.cs
@@ -9,13 +9,17 @@ namespace Serilog.Settings.Configuration.Tests
 {
     public class DllScanningAssemblyFinderTests : IDisposable
     {
+        const string BinDir1 = "bin1";
+        const string BinDir2 = "bin2";
+        const string BinDir3 = "bin3";
+
         readonly string _privateBinPath;
 
         public DllScanningAssemblyFinderTests()
         {
-            var d1 = GetOrCreateDirectory("bin1");
-            var d2 = GetOrCreateDirectory("bin2");
-            var d3 = GetOrCreateDirectory("bin3");
+            var d1 = GetOrCreateDirectory(BinDir1);
+            var d2 = GetOrCreateDirectory(BinDir2);
+            var d3 = GetOrCreateDirectory(BinDir3);
 
             _privateBinPath = $"{d1.Name};{d2.FullName};{d3.Name}";
 
@@ -25,9 +29,9 @@ namespace Serilog.Settings.Configuration.Tests
 
         public void Dispose()
         {
-            Directory.Delete("bin1", true);
-            Directory.Delete("bin2", true);
-            Directory.Delete("bin3", true);
+            Directory.Delete(BinDir1, true);
+            Directory.Delete(BinDir2, true);
+            Directory.Delete(BinDir3, true);
         }
 
         [Fact]
@@ -41,9 +45,9 @@ namespace Serilog.Settings.Configuration.Tests
         [Fact]
         public void ShouldProbePrivateBinPath()
         {
-            File.Copy("testdummies.dll", "bin1/customSink1.dll", true);
-            File.Copy("testdummies.dll", "bin2/customSink2.dll", true);
-            File.Copy("testdummies.dll", "bin3/thirdpartydependency.dll", true);
+            File.Copy("testdummies.dll", $"{BinDir1}/customSink1.dll", true);
+            File.Copy("testdummies.dll", $"{BinDir2}/customSink2.dll", true);
+            File.Copy("testdummies.dll", $"{BinDir3}/thirdpartydependency.dll", true);
 
             var ad = AppDomain.CreateDomain("serilog", null,
                 new AppDomainSetup

--- a/test/Serilog.Settings.Configuration.Tests/DllScanningAssemblyFinderTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/DllScanningAssemblyFinderTests.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.IO;
+
+using Xunit;
+
+using Serilog.Settings.Configuration.Assemblies;
+
+namespace Serilog.Settings.Configuration.Tests
+{
+    public class DllScanningAssemblyFinderTests : IDisposable
+    {
+        readonly string _privateBinPath;
+
+        public DllScanningAssemblyFinderTests()
+        {
+            var d1 = GetOrCreateDirectory("bin1");
+            var d2 = GetOrCreateDirectory("bin2");
+            var d3 = GetOrCreateDirectory("bin3");
+
+            _privateBinPath = $"{d1.Name};{d2.FullName};{d3.Name}";
+
+            DirectoryInfo GetOrCreateDirectory(string name)
+                => Directory.Exists(name) ? new DirectoryInfo(name) : Directory.CreateDirectory(name);
+        }
+
+        public void Dispose()
+        {
+            Directory.Delete("bin1", true);
+            Directory.Delete("bin2", true);
+            Directory.Delete("bin3", true);
+        }
+
+        [Fact]
+        public void ShouldProbeCurrentDirectory()
+        {
+            var assemblyNames = new DllScanningAssemblyFinder().FindAssembliesContainingName("testdummies");
+            Assert.Single(assemblyNames);
+        }
+
+#if PRIVATE_BIN
+        [Fact]
+        public void ShouldProbePrivateBinPath()
+        {
+            File.Copy("testdummies.dll", "bin1/customSink1.dll", true);
+            File.Copy("testdummies.dll", "bin2/customSink2.dll", true);
+            File.Copy("testdummies.dll", "bin3/thirdpartydependency.dll", true);
+
+            var ad = AppDomain.CreateDomain("serilog", null,
+                new AppDomainSetup
+                {
+                    ApplicationBase = AppDomain.CurrentDomain.BaseDirectory,
+                    PrivateBinPath = _privateBinPath
+                });
+
+            try
+            {
+                ad.DoCallBack(DoTestInner);
+            }
+            finally
+            {
+                AppDomain.Unload(ad);
+            }
+
+            void DoTestInner()
+            {
+                var assemblyNames = new DllScanningAssemblyFinder().FindAssembliesContainingName("customSink");
+                Assert.Equal(2, assemblyNames.Count);
+            }
+        }
+#endif
+    }
+}

--- a/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
+++ b/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
@@ -19,6 +19,10 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
   </PropertyGroup>
 
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net452'">
+    <DefineConstants>$(DefineConstants);PRIVATE_BIN</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Serilog.Settings.Configuration\Serilog.Settings.Configuration.csproj" />
     <ProjectReference Include="..\TestDummies\TestDummies.csproj" />


### PR DESCRIPTION
- `ArgumentNullException` fix when `AppDomain.CurrentDomain.BaseDirectory` is null
- additional paths probing:  `AppDomainSetup.PrivateBinPath`, current assembly location path when `BaseDirectory` is null

Fixes [#150](https://github.com/serilog/serilog-settings-configuration/issues/150), [#157](https://github.com/serilog/serilog-settings-configuration/issues/157), [#122](https://github.com/serilog/serilog-settings-configuration/issues/122), [#156](https://github.com/serilog/serilog-settings-configuration/issues/156)