### PR TITLE
Respect dynamic logging level changes for LevelSwitch section

### DIFF
--- a/sample/Sample/appsettings.json
+++ b/sample/Sample/appsettings.json
@@ -1,6 +1,7 @@
 ﻿{
   "Serilog": {
-    "Using":  ["Serilog.Sinks.Console"],
+    "Using": [ "Serilog.Sinks.Console" ],
+    "LevelSwitches": { "$controlSwitch": "Verbose" },
     "MinimumLevel": {
       "Default": "Debug",
       "Override": {
@@ -12,6 +13,7 @@
       "Name": "Logger",
       "Args": {
         "configureLogger": {
+          "MinimumLevel": "Verbose",
           "WriteTo": [
             {
               "Name": "Console",
@@ -22,7 +24,8 @@
             }
           ]
         },
-        "restrictedToMinimumLevel": "Debug"
+        "restrictedToMinimumLevel": "Verbose",
+        "levelSwitch": "$controlSwitch"
       }
     },
     "WriteTo:Async": {
@@ -39,7 +42,7 @@
         ]
       }
     },
-    "Enrich": ["FromLogContext", "WithMachineName", "WithThreadId"],
+    "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ],
     "Properties": {
       "Application": "Sample"
     },

--- a/test/Serilog.Settings.Configuration.Tests/DynamicLevelChangeTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/DynamicLevelChangeTests.cs
@@ -32,7 +32,7 @@ namespace Serilog.Settings.Configuration.Tests
                 Path = ConfigFilename,
                 Optional = false,
                 ReloadOnChange = true,
-                ReloadDelay = 10
+                ReloadDelay = 100
             };
 
             jsonConfigurationSource.ResolveFileProvider();
@@ -80,7 +80,7 @@ namespace Serilog.Settings.Configuration.Tests
         void UpdateConfig(LogEventLevel? minimumLevel = null, LogEventLevel? overrideLevel = null, LogEventLevel? switchLevel = null)
         {
             File.WriteAllText(ConfigFilename, BuildConfiguration());
-            Thread.Sleep(50);
+            Thread.Sleep(250);
 
             string BuildConfiguration()
             {

--- a/test/Serilog.Settings.Configuration.Tests/DynamicLevelChangeTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/DynamicLevelChangeTests.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.IO;
+using System.Threading;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Json;
+
+using Serilog.Core;
+using Serilog.Events;
+using Serilog.Settings.Configuration.Tests.Support;
+
+using Xunit;
+using TestDummies.Console;
+
+namespace Serilog.Settings.Configuration.Tests
+{
+    public class DynamicLevelChangeTests : IDisposable
+    {
+        const string ConfigFilename = "dynamicLevels.json";
+
+        readonly IConfigurationRoot _config;
+
+        LogEventLevel _minimumLevel, _overrideLevel, _switchLevel;
+
+        public DynamicLevelChangeTests()
+        {
+            UpdateConfig(LogEventLevel.Information, LogEventLevel.Information, LogEventLevel.Information);
+
+            var jsonConfigurationSource = new JsonConfigurationSource
+            {
+                FileProvider = null,
+                Path = ConfigFilename,
+                Optional = false,
+                ReloadOnChange = true,
+                ReloadDelay = 10
+            };
+
+            jsonConfigurationSource.ResolveFileProvider();
+
+            _config = new ConfigurationBuilder()
+                .Add(jsonConfigurationSource)
+                .Build();
+        }
+
+        public void Dispose()
+        {
+            if (File.Exists(ConfigFilename))
+            {
+                File.Delete(ConfigFilename);
+            }
+        }
+
+        [Fact]
+        public void ShouldRespectDynamicLevelChanges()
+        {
+            using (var logger = new LoggerConfiguration().ReadFrom.Configuration(_config).CreateLogger())
+            {
+                DummyConsoleSink.Emitted.Clear();
+                logger.Write(Some.DebugEvent());
+                Assert.Empty(DummyConsoleSink.Emitted);
+
+                DummyConsoleSink.Emitted.Clear();
+                UpdateConfig(minimumLevel: LogEventLevel.Debug);
+                logger.Write(Some.DebugEvent());
+                Assert.Empty(DummyConsoleSink.Emitted);
+
+                DummyConsoleSink.Emitted.Clear();
+                UpdateConfig(switchLevel: LogEventLevel.Debug);
+                logger.Write(Some.DebugEvent());
+                logger.ForContext(Constants.SourceContextPropertyName, "Root.Test").Write(Some.DebugEvent());
+                Assert.Single(DummyConsoleSink.Emitted);
+
+                DummyConsoleSink.Emitted.Clear();
+                UpdateConfig(overrideLevel: LogEventLevel.Debug);
+                logger.ForContext(Constants.SourceContextPropertyName, "Root.Test").Write(Some.DebugEvent());
+                Assert.Single(DummyConsoleSink.Emitted);
+            }
+        }
+
+        void UpdateConfig(LogEventLevel? minimumLevel = null, LogEventLevel? overrideLevel = null, LogEventLevel? switchLevel = null)
+        {
+            File.WriteAllText(ConfigFilename, BuildConfiguration());
+            Thread.Sleep(50);
+
+            string BuildConfiguration()
+            {
+                _minimumLevel = minimumLevel ?? _minimumLevel;
+                _overrideLevel = overrideLevel ?? _overrideLevel;
+                _switchLevel = switchLevel ?? _switchLevel;
+
+                var config = @"{
+                    'Serilog': {
+                        'Using': [ 'TestDummies' ],
+                        'MinimumLevel': {
+                            'Default': '" + _minimumLevel + @"',
+                            'Override': {
+                                'Root.Test': '" + _overrideLevel + @"'
+                            }
+                        },
+                        'LevelSwitches': { '$mySwitch': '" + _switchLevel + @"' },
+                        'WriteTo:Dummy': {
+                            'Name': 'DummyConsole',
+                            'Args': {
+                                'levelSwitch': '$mySwitch'
+                            }
+                        }
+                    }
+                }";
+
+                return config;
+            }
+        }
+    }
+}

--- a/test/Serilog.Settings.Configuration.Tests/DynamicLevelChangeTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/DynamicLevelChangeTests.cs
@@ -26,19 +26,8 @@ namespace Serilog.Settings.Configuration.Tests
         {
             UpdateConfig(LogEventLevel.Information, LogEventLevel.Information, LogEventLevel.Information);
 
-            var jsonConfigurationSource = new JsonConfigurationSource
-            {
-                FileProvider = null,
-                Path = ConfigFilename,
-                Optional = false,
-                ReloadOnChange = true,
-                ReloadDelay = 100
-            };
-
-            jsonConfigurationSource.ResolveFileProvider();
-
             _config = new ConfigurationBuilder()
-                .Add(jsonConfigurationSource)
+                .AddJsonFile(ConfigFilename, false, true)
                 .Build();
         }
 
@@ -80,7 +69,7 @@ namespace Serilog.Settings.Configuration.Tests
         void UpdateConfig(LogEventLevel? minimumLevel = null, LogEventLevel? overrideLevel = null, LogEventLevel? switchLevel = null)
         {
             File.WriteAllText(ConfigFilename, BuildConfiguration());
-            Thread.Sleep(250);
+            Thread.Sleep(300);
 
             string BuildConfiguration()
             {

--- a/test/Serilog.Settings.Configuration.Tests/DynamicLevelChangeTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/DynamicLevelChangeTests.cs
@@ -65,26 +65,26 @@ namespace Serilog.Settings.Configuration.Tests
                 logger.ForContext(Constants.SourceContextPropertyName, "Root.Test").Write(Some.DebugEvent());
                 Assert.Single(DummyConsoleSink.Emitted);
             }
+        }
 
-            void UpdateConfig(LogEventLevel? minimumLevel = null, LogEventLevel? switchLevel = null, LogEventLevel? overrideLevel = null)
+        void UpdateConfig(LogEventLevel? minimumLevel = null, LogEventLevel? switchLevel = null, LogEventLevel? overrideLevel = null)
+        {
+            if (minimumLevel.HasValue)
             {
-                if (minimumLevel.HasValue)
-                {
-                    _configSource.Set("Serilog:MinimumLevel:Default", minimumLevel.Value.ToString());
-                }
-
-                if (switchLevel.HasValue)
-                {
-                    _configSource.Set("Serilog:LevelSwitches:$mySwitch", switchLevel.Value.ToString());
-                }
-
-                if (overrideLevel.HasValue)
-                {
-                    _configSource.Set("Serilog:MinimumLevel:Override:Root.Test", overrideLevel.Value.ToString());
-                }
-
-                _configSource.Reload();
+                _configSource.Set("Serilog:MinimumLevel:Default", minimumLevel.Value.ToString());
             }
+
+            if (switchLevel.HasValue)
+            {
+                _configSource.Set("Serilog:LevelSwitches:$mySwitch", switchLevel.Value.ToString());
+            }
+
+            if (overrideLevel.HasValue)
+            {
+                _configSource.Set("Serilog:MinimumLevel:Override:Root.Test", overrideLevel.Value.ToString());
+            }
+
+            _configSource.Reload();
         }
     }
 }

--- a/test/Serilog.Settings.Configuration.Tests/StringArgumentValueTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/StringArgumentValueTests.cs
@@ -15,7 +15,7 @@ namespace Serilog.Settings.Configuration.Tests
         [Fact]
         public void StringValuesConvertToDefaultInstancesIfTargetIsInterface()
         {
-            var stringArgumentValue = new StringArgumentValue(() => "Serilog.Formatting.Json.JsonFormatter, Serilog");
+            var stringArgumentValue = new StringArgumentValue("Serilog.Formatting.Json.JsonFormatter, Serilog");
 
             var result = stringArgumentValue.ConvertTo(typeof(ITextFormatter), new ResolutionContext());
 
@@ -25,7 +25,7 @@ namespace Serilog.Settings.Configuration.Tests
         [Fact]
         public void StringValuesConvertToDefaultInstancesIfTargetIsAbstractClass()
         {
-            var stringArgumentValue = new StringArgumentValue(() => "Serilog.Settings.Configuration.Tests.Support.ConcreteClass, Serilog.Settings.Configuration.Tests");
+            var stringArgumentValue = new StringArgumentValue("Serilog.Settings.Configuration.Tests.Support.ConcreteClass, Serilog.Settings.Configuration.Tests");
 
             var result = stringArgumentValue.ConvertTo(typeof(AbstractClass), new ResolutionContext());
 
@@ -81,7 +81,7 @@ namespace Serilog.Settings.Configuration.Tests
         [InlineData("Serilog.Settings.Configuration.Tests.Support.ClassWithStaticAccessors::AbstractField, Serilog.Settings.Configuration.Tests", typeof(AnAbstractClass))]
         public void StaticMembersAccessorsCanBeUsedForReferenceTypes(string input, Type targetType)
         {
-            var stringArgumentValue = new StringArgumentValue(() => $"{input}");
+            var stringArgumentValue = new StringArgumentValue($"{input}");
 
             var actual = stringArgumentValue.ConvertTo(targetType, new ResolutionContext());
 
@@ -98,7 +98,7 @@ namespace Serilog.Settings.Configuration.Tests
         [InlineData("Serilog.Settings.Configuration.Tests.Support.ClassWithStaticAccessors::InterfaceProperty", typeof(IAmAnInterface))]
         public void StaticAccessorOnUnknownTypeThrowsTypeLoadException(string input, Type targetType)
         {
-            var stringArgumentValue = new StringArgumentValue(() => $"{input}");
+            var stringArgumentValue = new StringArgumentValue($"{input}");
             Assert.Throws<TypeLoadException>(() =>
                 stringArgumentValue.ConvertTo(targetType, new ResolutionContext())
             );
@@ -117,7 +117,7 @@ namespace Serilog.Settings.Configuration.Tests
         [InlineData("Serilog.Settings.Configuration.Tests.Support.ClassWithStaticAccessors::InstanceInterfaceField, Serilog.Settings.Configuration.Tests", typeof(IAmAnInterface))]
         public void StaticAccessorWithInvalidMemberThrowsInvalidOperationException(string input, Type targetType)
         {
-            var stringArgumentValue = new StringArgumentValue(() => $"{input}");
+            var stringArgumentValue = new StringArgumentValue($"{input}");
             var exception = Assert.Throws<InvalidOperationException>(() =>
                 stringArgumentValue.ConvertTo(targetType, new ResolutionContext())
             );
@@ -134,7 +134,7 @@ namespace Serilog.Settings.Configuration.Tests
             var resolutionContext = new ResolutionContext();
             resolutionContext.AddLevelSwitch(switchName, @switch);
 
-            var stringArgumentValue = new StringArgumentValue(() => switchName);
+            var stringArgumentValue = new StringArgumentValue(switchName);
 
             var resolvedSwitch = stringArgumentValue.ConvertTo(typeof(LoggingLevelSwitch), resolutionContext);
 
@@ -149,7 +149,7 @@ namespace Serilog.Settings.Configuration.Tests
             var resolutionContext = new ResolutionContext();
             resolutionContext.AddLevelSwitch("$anotherSwitch", new LoggingLevelSwitch(LogEventLevel.Verbose));
 
-            var stringArgumentValue = new StringArgumentValue(() => "$mySwitch");
+            var stringArgumentValue = new StringArgumentValue("$mySwitch");
 
             var ex = Assert.Throws<InvalidOperationException>(() =>
                 stringArgumentValue.ConvertTo(typeof(LoggingLevelSwitch), resolutionContext)
@@ -163,7 +163,7 @@ namespace Serilog.Settings.Configuration.Tests
         public void StringValuesConvertToTypeFromShortTypeName()
         {
             var shortTypeName = "System.Version";
-            var stringArgumentValue = new StringArgumentValue(() => shortTypeName);
+            var stringArgumentValue = new StringArgumentValue(shortTypeName);
 
             var actual = (Type)stringArgumentValue.ConvertTo(typeof(Type), new ResolutionContext());
 
@@ -174,7 +174,7 @@ namespace Serilog.Settings.Configuration.Tests
         public void StringValuesConvertToTypeFromAssemblyQualifiedName()
         {
             var assemblyQualifiedName = typeof(Version).AssemblyQualifiedName;
-            var stringArgumentValue = new StringArgumentValue(() => assemblyQualifiedName);
+            var stringArgumentValue = new StringArgumentValue(assemblyQualifiedName);
 
             var actual = (Type)stringArgumentValue.ConvertTo(typeof(Type), new ResolutionContext());
 

--- a/test/Serilog.Settings.Configuration.Tests/Support/JsonStringConfigSource.cs
+++ b/test/Serilog.Settings.Configuration.Tests/Support/JsonStringConfigSource.cs
@@ -1,7 +1,8 @@
-﻿using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Configuration.Json;
-
+﻿using System.Collections.Generic;
 using System.IO;
+
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Configuration.Json;
 
 namespace Serilog.Settings.Configuration.Tests.Support
 {
@@ -24,6 +25,13 @@ namespace Serilog.Settings.Configuration.Tests.Support
             return new ConfigurationBuilder().Add(new JsonStringConfigSource(json)).Build().GetSection(section);
         }
 
+        public static IDictionary<string, string> LoadData(string json)
+        {
+            var provider = new JsonStringConfigProvider(json);
+            provider.Load();
+            return provider.Data;
+        }
+
         class JsonStringConfigProvider : JsonConfigurationProvider
         {
             readonly string _json;
@@ -32,6 +40,8 @@ namespace Serilog.Settings.Configuration.Tests.Support
             {
                 _json = json;
             }
+
+            public new IDictionary<string, string> Data => base.Data;
 
             public override void Load()
             {

--- a/test/Serilog.Settings.Configuration.Tests/Support/ReloadableConfigurationSource.cs
+++ b/test/Serilog.Settings.Configuration.Tests/Support/ReloadableConfigurationSource.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using Microsoft.Extensions.Configuration;
+
+namespace Serilog.Settings.Configuration.Tests.Support
+{
+    class ReloadableConfigurationSource : IConfigurationSource
+    {
+        readonly ReloadableConfigurationProvider _configProvider;
+        readonly IDictionary<string, string> _source;
+
+        public ReloadableConfigurationSource(IDictionary<string, string> source)
+        {
+            _source = source;
+            _configProvider = new ReloadableConfigurationProvider(source);
+        }
+
+        public IConfigurationProvider Build(IConfigurationBuilder builder) => _configProvider;
+
+        public void Reload() => _configProvider.Reload();
+
+        public void Set(string key, string value) => _source[key] = value;
+
+        class ReloadableConfigurationProvider : ConfigurationProvider
+        {
+            readonly IDictionary<string, string> _source;
+
+            public ReloadableConfigurationProvider(IDictionary<string, string> source)
+            {
+                _source = source;
+            }
+
+            public override void Load() => Data = _source;
+
+            public void Reload() => OnReload();
+        }
+    }
+}

--- a/test/TestDummies/Console/DummyConsoleSink.cs
+++ b/test/TestDummies/Console/DummyConsoleSink.cs
@@ -17,9 +17,9 @@ namespace TestDummies.Console
         public static ConsoleTheme Theme;
 
         [ThreadStatic]
-        // ReSharper disable ThreadStaticFieldHasInitializer
-        public static List<LogEvent> Emitted = new List<LogEvent>();
-        // ReSharper restore ThreadStaticFieldHasInitializer
+        static List<LogEvent> EmittedList = new List<LogEvent>();
+
+        public static List<LogEvent> Emitted => EmittedList ?? (EmittedList = new List<LogEvent>());
 
         public void Emit(LogEvent logEvent)
         {

--- a/test/TestDummies/DummyLoggerConfigurationExtensions.cs
+++ b/test/TestDummies/DummyLoggerConfigurationExtensions.cs
@@ -109,9 +109,10 @@ namespace TestDummies
         public static LoggerConfiguration DummyConsole(
             this LoggerSinkConfiguration loggerSinkConfiguration,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LoggingLevelSwitch levelSwitch = null,
             ConsoleTheme theme = null)
         {
-            return loggerSinkConfiguration.Sink(new DummyConsoleSink(theme), restrictedToMinimumLevel);
+            return loggerSinkConfiguration.Sink(new DummyConsoleSink(theme), restrictedToMinimumLevel, levelSwitch);
         }
 
         public static LoggerConfiguration Dummy(


### PR DESCRIPTION
- dynamic level changes notifications for `LevelSwitch` section
- tests added
- NRE fix for `DummyConsoleSink`
- unused / unreachable related junk removed
- sample updated

Fixes [#99](https://github.com/serilog/serilog-settings-configuration/issues/99)