### PR TITLE
Support simple type names for Serilog types (fixes #81)

### DIFF
--- a/src/Serilog.Settings.Configuration/Settings/Configuration/StringArgumentValue.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/StringArgumentValue.cs
@@ -97,7 +97,7 @@ namespace Serilog.Settings.Configuration
 
                 // maybe it's the assembly-qualified type name of a concrete implementation
                 // with a default constructor
-                var type = Type.GetType(argumentValue.Trim());
+                var type = FindType(argumentValue.Trim());
                 if (type != null)
                 {
                     var ctor = type.GetTypeInfo().DeclaredConstructors.FirstOrDefault(ci =>
@@ -140,6 +140,20 @@ namespace Serilog.Settings.Configuration
             }
 
             return Convert.ChangeType(argumentValue, toType);
+        }
+
+        internal static Type FindType(string typeName)
+        {
+            var type = Type.GetType(typeName);
+            if (type == null)
+            {
+                if (!typeName.Contains(','))
+                {
+                    type = Type.GetType($"{typeName}, Serilog");
+                }
+            }
+
+            return type;
         }
 
         internal static bool TryParseStaticMemberAccessor(string input, out string accessorTypeName, out string memberName)

--- a/test/Serilog.Settings.Configuration.Tests/StringArgumentValueTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/StringArgumentValueTests.cs
@@ -75,6 +75,16 @@ namespace Serilog.Settings.Configuration.Tests
         }
 
         [Theory]
+        [InlineData("Serilog.Formatting.Json.JsonFormatter", typeof(JsonFormatter))]
+        [InlineData("Serilog.Formatting.Json.JsonFormatter, Serilog", typeof(JsonFormatter))]
+        [InlineData("Serilog.ConfigurationLoggerConfigurationExtensions", typeof(ConfigurationLoggerConfigurationExtensions))]
+        public void FindTypeSupportsSimpleNamesForSerilogTypes(string input, Type targetType)
+        {
+            var type = StringArgumentValue.FindType(input);
+            Assert.Equal(targetType, type);
+        }
+
+        [Theory]
         [InlineData("Serilog.Settings.Configuration.Tests.Support.ClassWithStaticAccessors::InterfaceProperty, Serilog.Settings.Configuration.Tests", typeof(IAmAnInterface))]
         [InlineData("Serilog.Settings.Configuration.Tests.Support.ClassWithStaticAccessors::AbstractProperty, Serilog.Settings.Configuration.Tests", typeof(AnAbstractClass))]
         [InlineData("Serilog.Settings.Configuration.Tests.Support.ClassWithStaticAccessors::InterfaceField, Serilog.Settings.Configuration.Tests", typeof(IAmAnInterface))]


### PR DESCRIPTION
Fixes [#81](https://github.com/serilog/serilog-settings-configuration/issues/81)