### PR TITLE
Update Microsoft.Extensions.DependencyModel to v3

### DIFF
--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -30,15 +30,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="2.0.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.0.0" />
     <PackageReference Include="Serilog" Version="2.6.0" />
     <None Include="..\..\assets\icon.png" Pack="true" PackagePath=""/>
   </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework) == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.NETCore.Targets" Version="3.0.0" />
-  </ItemGroup>
-
+  
   <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.2" />
   </ItemGroup>


### PR DESCRIPTION
- fixes [#197](https://github.com/serilog/serilog-settings-configuration/issues/197) to some extent for `netstandard2.0` target: the new package uses `System.Text.Json` instead of  `Newtonsoft.Json` to parse `.deps.json` files.
- no need to use workaround from [#218](https://github.com/serilog/serilog-settings-configuration/pull/218) since the new package doesn't bring .NET Core 1.x transitive dependencies, as `2.0.4` of `Microsoft.Extensions.DependencyModel` does.