### PR TITLE
Minimumlevel partial fix with IConfigurationRoot.Providers

### DIFF
--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -22,12 +22,19 @@ namespace Serilog.Settings.Configuration
         readonly IConfigurationSection _section;
         readonly IReadOnlyCollection<Assembly> _configurationAssemblies;
         readonly ResolutionContext _resolutionContext;
+#if NETSTANDARD || NET461
+        readonly IConfigurationRoot _configurationRoot;
+#endif
 
         public ConfigurationReader(IConfigurationSection configSection, AssemblyFinder assemblyFinder, IConfiguration configuration = null)
         {
             _section = configSection ?? throw new ArgumentNullException(nameof(configSection));
             _configurationAssemblies = LoadConfigurationAssemblies(_section, assemblyFinder);
             _resolutionContext = new ResolutionContext(configuration);
+#if NETSTANDARD || NET461
+            _configurationRoot = configuration as IConfigurationRoot;
+#endif
+
         }
 
         // Used internally for processing nested configuration sections -- see GetMethodCalls below.
@@ -85,7 +92,7 @@ namespace Serilog.Settings.Configuration
         {
             var minimumLevelDirective = _section.GetSection("MinimumLevel");
 
-            var defaultMinLevelDirective = minimumLevelDirective.Value != null ? minimumLevelDirective : minimumLevelDirective.GetSection("Default");
+            IConfigurationSection defaultMinLevelDirective = GetDefaultMinLevelDirective();
             if (defaultMinLevelDirective.Value != null)
             {
                 ApplyMinimumLevel(defaultMinLevelDirective, (configuration, levelSwitch) => configuration.ControlledBy(levelSwitch));
@@ -123,6 +130,35 @@ namespace Serilog.Settings.Configuration
                 applyConfigAction(loggerConfiguration.MinimumLevel, levelSwitch);
 
                 SubscribeToLoggingLevelChanges(directive, levelSwitch);
+            }
+
+            IConfigurationSection GetDefaultMinLevelDirective()
+            {
+                #if NETSTANDARD || NET461
+
+                var defaultLevelDirective = minimumLevelDirective.GetSection("Default");
+                if (_configurationRoot != null && minimumLevelDirective.Value != null && defaultLevelDirective.Value != null)
+                {
+                    foreach (var provider in _configurationRoot.Providers.Reverse())
+                    {
+                        if (provider.TryGet(minimumLevelDirective.Path, out _))
+                        {
+                            return _configurationRoot.GetSection(minimumLevelDirective.Path);
+                        }
+
+                        if (provider.TryGet(defaultLevelDirective.Path, out _))
+                        {
+                            return _configurationRoot.GetSection(defaultLevelDirective.Path);
+                        }
+                    }
+
+                    return null;
+                }
+
+                #endif //NET451 or fallback
+
+                return minimumLevelDirective.Value != null ? minimumLevelDirective : minimumLevelDirective.GetSection("Default");
+
             }
         }
 

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -34,7 +34,6 @@ namespace Serilog.Settings.Configuration
 #if NETSTANDARD || NET461
             _configurationRoot = configuration as IConfigurationRoot;
 #endif
-
         }
 
         // Used internally for processing nested configuration sections -- see GetMethodCalls below.
@@ -43,6 +42,9 @@ namespace Serilog.Settings.Configuration
             _section = configSection ?? throw new ArgumentNullException(nameof(configSection));
             _configurationAssemblies = configurationAssemblies ?? throw new ArgumentNullException(nameof(configurationAssemblies));
             _resolutionContext = resolutionContext ?? throw new ArgumentNullException(nameof(resolutionContext));
+            #if NETSTANDARD || NET461
+            _configurationRoot = resolutionContext.HasAppConfiguration ? resolutionContext.AppConfiguration as IConfigurationRoot : null;
+            #endif
         }
 
         public void Configure(LoggerConfiguration loggerConfiguration)
@@ -158,7 +160,6 @@ namespace Serilog.Settings.Configuration
                 #endif //NET451 or fallback
 
                 return minimumLevelDirective.Value != null ? minimumLevelDirective : minimumLevelDirective.GetSection("Default");
-
             }
         }
 

--- a/test/Serilog.Settings.Configuration.Tests/Support/ConfigurationReaderTestHelpers.cs
+++ b/test/Serilog.Settings.Configuration.Tests/Support/ConfigurationReaderTestHelpers.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Configuration;
+using Serilog.Events;
+using Xunit;
+
+namespace Serilog.Settings.Configuration.Tests.Support
+{
+    static class ConfigurationReaderTestHelpers
+    {
+        public const string minimumLevelFlatTemplate = @"
+{{
+    'Serilog': {{
+        'MinimumLevel': '{0}'
+    }}
+}}";
+        public const string minimumLevelObjectTemplate = @"
+{{
+    'Serilog': {{
+        'MinimumLevel': {{
+            'Default': '{0}'
+        }}
+    }}
+}}";
+        public const string minimumLevelFlatKey = "Serilog:MinimumLevel";
+        public const string minimumLevelObjectKey = "Serilog:MinimumLevel:Default";
+
+        public static void AssertLogEventLevels(LoggerConfiguration loggerConfig, LogEventLevel expectedMinimumLevel)
+        {
+            var logger = loggerConfig.CreateLogger();
+
+            var logEventValues = Enum.GetValues(typeof(LogEventLevel)).Cast<LogEventLevel>();
+
+            foreach (var logEvent in logEventValues)
+            {
+                if (logEvent < expectedMinimumLevel)
+                {
+                    Assert.False(logger.IsEnabled(logEvent),
+                        $"The log level {logEvent} should be disabled as it's lower priority than the minimum level of {expectedMinimumLevel}.");
+                }
+                else
+                {
+                    Assert.True(logger.IsEnabled(logEvent),
+                        $"The log level {logEvent} should be enabled as it's {(logEvent == expectedMinimumLevel ? "the same" : "higher")} priority {(logEvent == expectedMinimumLevel ? "as" : "than")} the minimum level of {expectedMinimumLevel}.");
+                }
+            }
+        }
+
+        // the naming is only to show priority as providers
+        public static IConfigurationRoot GetConfigRoot(
+            string appsettingsJsonLevel = null,
+            string appsettingsDevelopmentJsonLevel = null,
+            Dictionary<string, string> envVariables = null)
+        {
+            var configBuilder = new ConfigurationBuilder();
+
+            configBuilder.AddJsonString(appsettingsJsonLevel            ?? "{}");
+            configBuilder.AddJsonString(appsettingsDevelopmentJsonLevel ?? "{}");
+            configBuilder.Add(new ReloadableConfigurationSource(envVariables ?? new Dictionary<string, string>()));
+
+            return configBuilder.Build();
+        }
+    }
+}

--- a/test/Serilog.Settings.Configuration.Tests/Support/Extensions.cs
+++ b/test/Serilog.Settings.Configuration.Tests/Support/Extensions.cs
@@ -18,5 +18,7 @@ namespace Serilog.Settings.Configuration.Tests.Support
 #endif
             return str;
         }
+
+        public static string Format(this string template, params object[] paramObjects) => string.Format(template, paramObjects);
     }
 }


### PR DESCRIPTION
A partial fix for minimumlevel not being correctly overriden by higher priority providers.

The fix only works for the .NET 4.6.1+ and .NET Standard builds as the IConfigurationRoot interface did not have Providers in .NET 4.5.1. 

I understand this is more of an annoyance than a real issue, but it's easy to miss.