### PR TITLE
Support of constructor parameters

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+3.3.0
+
+* #276, #225, #167 - added support for constructors with arguments for complex types
+
 3.2.0
 
 * #162 - LoggingFilterSwitch support

--- a/README.md
+++ b/README.md
@@ -293,8 +293,7 @@ If the parameter value is not a discrete value, it will try to find a best match
     "formatter": {
       // `type` (or $type) is optional, must be specified for abstract declared parameter types
       "type": "Serilog.Templates.ExpressionTemplate, Serilog.Expressions",
-      "template": "[{@t:HH:mm:ss} {@l:u3} {Coalesce(SourceContext, '<none>')}] {@m}\n{@x}",
-      "formatProvider": "System.Globalization.CultureInfo::InvariantCulture"
+      "template": "[{@t:HH:mm:ss} {@l:u3} {Coalesce(SourceContext, '<none>')}] {@m}\n{@x}"
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -284,7 +284,22 @@ Static member access can be used for passing to the configuration argument via [
 
 ### Complex parameter value binding
 
-If the parameter value is not a discrete value, the package will use the configuration binding system provided by _[Microsoft.Extensions.Options.ConfigurationExtensions](https://www.nuget.org/packages/Microsoft.Extensions.Options.ConfigurationExtensions/)_ to attempt to populate the parameter. Almost anything that can be bound by `IConfiguration.Get<T>` should work with this package. An example of this is the optional `List<Column>` parameter used to configure the .NET Standard version of the _[Serilog.Sinks.MSSqlServer](https://github.com/serilog/serilog-sinks-mssqlserver)_ package.
+If the parameter value is not a discrete value, it will try to find a best matching public constructor for the argument:
+
+```json
+{
+  "Name": "Console",
+  "Args": {
+    "formatter": {
+      // `type` (or $type) is optional, must be specified for abstract declared parameter types
+      "type": "Serilog.Templates.ExpressionTemplate, Serilog.Expressions",
+      "template": "[{@t:HH:mm:ss} {@l:u3} {Coalesce(SourceContext, '<none>')}] {@m}\n{@x}",
+      "formatProvider": "System.Globalization.CultureInfo::InvariantCulture"
+  }
+}
+```
+
+For other cases the package will use the configuration binding system provided by _[Microsoft.Extensions.Options.ConfigurationExtensions](https://www.nuget.org/packages/Microsoft.Extensions.Options.ConfigurationExtensions/)_ to attempt to populate the parameter. Almost anything that can be bound by `IConfiguration.Get<T>` should work with this package. An example of this is the optional `List<Column>` parameter used to configure the .NET Standard version of the _[Serilog.Sinks.MSSqlServer](https://github.com/serilog/serilog-sinks-mssqlserver)_ package.
 
 ### Abstract parameter types
 

--- a/sample/Sample/Program.cs
+++ b/sample/Sample/Program.cs
@@ -63,9 +63,16 @@ namespace Sample
     // processed by the Serilog.Filters.Expressions package.
     public class CustomFilter : ILogEventFilter
     {
+        readonly LogEventLevel _levelFilter;
+
+        public CustomFilter(LogEventLevel levelFilter = LogEventLevel.Information)
+        {
+            _levelFilter = levelFilter;
+        }
+
         public bool IsEnabled(LogEvent logEvent)
         {
-            return true;
+            return logEvent.Level >= _levelFilter;
         }
     }
 

--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -38,6 +38,7 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
+    <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
   </ItemGroup>
 

--- a/sample/Sample/appsettings.json
+++ b/sample/Sample/appsettings.json
@@ -51,7 +51,13 @@
           {
             "Name": "File",
             "Args": {
-              "path": "%TEMP%/Logs/serilog-configuration-sample-errors.txt"
+              "path": "%TEMP%/Logs/serilog-configuration-sample-errors.txt",
+              "formatter": {
+                "type": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact",
+                "valueFormatter": {
+                  "typeTagName": "customTypeTag"
+                }
+              }
             }
           }
         ]
@@ -106,7 +112,10 @@
       {
         "Name": "With",
         "Args": {
-          "filter": "Sample.CustomFilter, Sample"
+          "filter": {
+            "type": "Sample.CustomFilter, Sample",
+            "levelFilter": "Verbose"
+          }
         }
       }
     ]

--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Microsoft.Extensions.Configuration (appsettings.json) support for Serilog.</Description>
-    <VersionPrefix>3.2.1</VersionPrefix>
+    <VersionPrefix>3.3.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Authors>Serilog Contributors</Authors>
     <TargetFrameworks>netstandard2.0;net451;net461</TargetFrameworks>

--- a/test/Serilog.Settings.Configuration.Tests/ObjectArgumentValueTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ObjectArgumentValueTests.cs
@@ -1,0 +1,68 @@
+﻿using System;
+
+using Microsoft.Extensions.Configuration;
+
+using Xunit;
+
+namespace Serilog.Settings.Configuration.Tests
+{
+    public class ObjectArgumentValueTests
+    {
+        readonly IConfigurationRoot _config;
+
+        public ObjectArgumentValueTests()
+        {
+            _config = new ConfigurationBuilder()
+                .AddJsonFile("ObjectArgumentValueTests.json")
+                .Build();
+        }
+
+        [Theory]
+        [InlineData("case_1", typeof(A), "new A(1, 23:59:59, http://dot.com/, \"d\")")]
+        [InlineData("case_2", typeof(B), "new B(2, new A(3, new D()), null)")]
+        [InlineData("case_3", typeof(E), "new E(\"1\", \"2\", \"3\")")]
+        [InlineData("case_4", typeof(F), "new F(\"paramType\", new E(1, 2, 3, 4))")]
+        [InlineData("case_5", typeof(G), "new G()")]
+        [InlineData("case_6", typeof(G), "new G(3, 4)")]
+        public void ShouldBindToConstructorArguments(string caseSection, Type targetType, string expectedExpression)
+        {
+            var testSection = _config.GetSection(caseSection);
+
+            Assert.True(ObjectArgumentValue.TryBuildCtorExpression(testSection, targetType, new(), out var ctorExpression));
+            Assert.Equal(expectedExpression, ctorExpression.ToString());
+        }
+
+        class A
+        {
+            public A(int a, TimeSpan b, Uri c, string d = "d") { }
+            public A(int a, C c) { }
+        }
+
+        class B
+        {
+            public B(int b, A a, long? c = null) { }
+        }
+
+        interface C { }
+
+        class D : C { }
+
+        class E
+        {
+            public E(int a, int b, int c, int d = 4) { }
+            public E(int a, string b, string c) { }
+            public E(string a, string b, string c) { }
+        }
+
+        class F
+        {
+            public F(string type, E e) { }
+        }
+
+        class G
+        {
+            public G() { }
+            public G(int a = 1, int b = 2) { }
+        }
+    }
+}

--- a/test/Serilog.Settings.Configuration.Tests/ObjectArgumentValueTests.json
+++ b/test/Serilog.Settings.Configuration.Tests/ObjectArgumentValueTests.json
@@ -1,0 +1,44 @@
+{
+  "case_1": {
+    "A": 1,
+    "b": "23:59:59",
+    "c": "http://dot.com/"
+  },
+
+  "case_2": {
+    "b": 2,
+    "A": {
+      "a": 3,
+      "c": {
+        "type": "Serilog.Settings.Configuration.Tests.ObjectArgumentValueTests+D, Serilog.Settings.Configuration.Tests"
+      }
+    }
+  },
+
+  "case_3": {
+    "a": 1,
+    "b": 2,
+    "c": 3
+  },
+
+  "case_4": {
+    "$type": "Serilog.Settings.Configuration.Tests.ObjectArgumentValueTests+F, Serilog.Settings.Configuration.Tests",
+    "type": "paramType",
+    "e": {
+      "type": "Serilog.Settings.Configuration.Tests.ObjectArgumentValueTests+E, Serilog.Settings.Configuration.Tests",
+      "a": 1,
+      "b": 2,
+      "c": 3,
+      "d": 4
+    }
+  },
+
+  "case_5": {
+
+  },
+
+  "case_6": {
+    "a": 3,
+    "b": 4
+  }
+}

--- a/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
+++ b/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
@@ -12,6 +12,12 @@
   <PropertyGroup Condition="'$(TargetFramework)' == 'net452'">
     <DefineConstants>$(DefineConstants);PRIVATE_BIN</DefineConstants>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <None Include="*.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Serilog.Settings.Configuration\Serilog.Settings.Configuration.csproj" />
@@ -35,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="Serilog.Filters.Expressions" Version="2.0.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
     <PackageReference Include="xunit" Version="2.2.0" />


### PR DESCRIPTION
Added support for constructor parameters (implementation of [second](https://github.com/serilog/serilog-settings-configuration/issues/276#issuecomment-902331271) design) including nested configurations and type binding that [StringArgumentValue](https://github.com/serilog/serilog-settings-configuration/blob/dev/src/Serilog.Settings.Configuration/Settings/Configuration/StringArgumentValue.cs#L11) supports.

```json
"formatter": {
  "type": "Serilog.Formatting.Compact.CompactJsonFormatter, Serilog.Formatting.Compact",
  "valueFormatter": {
    "typeTagName": "customTypeTag"
  }
},

"formatter": {
    "type": "Serilog.Templates.ExpressionTemplate, Serilog.Expressions",
    "template": "[{@t:HH:mm:ss} {@l:u3} {Coalesce(SourceContext, '<none>')}] {@m}\n{@x}",
    "formatProvider": "System.Globalization.CultureInfo::InvariantCulture"
}
```

1.  Prefix `$` for `type` is optional to go in line with [level/filter swithes declaration syntax](https://github.com/serilog/serilog-settings-configuration/pull/242)
2. `Ctor` overload matching follows the same algorithm that is used in [configuration method matching](https://github.com/serilog/serilog-settings-configuration/blob/dev/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs#L418)

- fixes #276, #225, #167

