### PR TITLE
Remove out of support target frameworks

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -43,9 +43,8 @@ foreach ($test in dir test/*.Tests) {
     echo "build: Testing project in $test"
 
     if ($PSVersionTable.Platform -eq "Unix") {
-        & dotnet test -c Release -f netcoreapp2.1
         & dotnet test -c Release -f netcoreapp3.1
-        & dotnet test -c Release -f net50
+        & dotnet test -c Release -f net6.0
     } else {
         & dotnet test -c Release
     }
@@ -58,13 +57,10 @@ foreach ($test in dir test/*.Tests) {
 if ($PSVersionTable.Platform -eq "Unix") {
     Push-Location sample/Sample
 
-    & dotnet run -f netcoreapp2.1 -c Release --run-once
-    if ($LASTEXITCODE -ne 0) { exit 4 }
-
     & dotnet run -f netcoreapp3.1 -c Release --run-once
     if ($LASTEXITCODE -ne 0) { exit 4 }
 
-    & dotnet run -f net50         -c Release --run-once
+    & dotnet run -f net6.0        -c Release --run-once
     if ($LASTEXITCODE -ne 0) { exit 4 }
 
     Pop-Location

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,6 +6,6 @@
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.2" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: '{build}'
 skip_tags: true
 image:
-  - Visual Studio 2019
+  - Visual Studio 2022
   - Ubuntu
 configuration: Release
 build_script:

--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net50;netcoreapp3.1;netcoreapp2.1;net46</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net462' ">
     <PreserveCompilationContext>false</PreserveCompilationContext>
   </PropertyGroup>
 
@@ -13,31 +13,13 @@
     <ProjectReference Include="..\..\src\Serilog.Settings.Configuration\Serilog.Settings.Configuration.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.1" />
-    <PackageReference Include="Serilog.Filters.Expressions" Version="2.1.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
-    <PackageReference Include="Serilog.Filters.Expressions" Version="2.1.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.10" />
-    <PackageReference Include="Serilog.Expressions" Version="1.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net50'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Serilog.Expressions" Version="1.0.0" />
-  </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Serilog.Sinks.Async" Version="1.4.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
-    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="Serilog.Enrichers.Environment" Version="2.2.0" />
+    <PackageReference Include="Serilog.Expressions" Version="3.3.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
   </ItemGroup>

--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -24,22 +24,18 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
-  <PropertyGroup Condition="('$(TargetFramework)' == 'net451') Or ('$(TargetFramework)' == 'net461')">
-    <DefineConstants>$(DefineConstants);PRIVATE_BIN</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
-    <None Include="..\..\assets\icon.png" Pack="true" PackagePath=""/>
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)' == 'net451'">
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="1.1.2" />
+    <None Include="..\..\assets\icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
 
-  <ItemGroup Condition="('$(TargetFramework)' == 'netstandard2.0') Or ('$(TargetFramework)' == 'net461')">
-    <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.0.0" />
+  <ItemGroup Condition="$(TargetFramework) == 'net451'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="1.1.2" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) != 'net451'">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/Assemblies/DllScanningAssemblyFinder.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/Assemblies/DllScanningAssemblyFinder.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -16,7 +16,7 @@ namespace Serilog.Settings.Configuration.Assemblies
             {
                 probeDirs.Add(AppDomain.CurrentDomain.BaseDirectory);
 
-#if PRIVATE_BIN
+#if NETFRAMEWORK
                 var privateBinPath = AppDomain.CurrentDomain.SetupInformation.PrivateBinPath;
                 if (!string.IsNullOrEmpty(privateBinPath))
                 {

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
@@ -31,8 +31,8 @@ namespace Serilog.Settings.Configuration.Tests
             Assert.True(result.Contains("LiterateConsole"));
             Assert.True(result.Contains("DiagnosticTrace"));
 
-            Assert.Equal(1, result["LiterateConsole"].Count());
-            Assert.Equal(1, result["DiagnosticTrace"].Count());
+            Assert.Single(result["LiterateConsole"]);
+            Assert.Single(result["DiagnosticTrace"]);
         }
 
         [Fact]
@@ -49,7 +49,7 @@ namespace Serilog.Settings.Configuration.Tests
             Assert.Equal(1, result.Count);
             Assert.True(result.Contains("LiterateConsole"));
 
-            Assert.Equal(1, result["LiterateConsole"].Count());
+            Assert.Single(result["LiterateConsole"]);
         }
 
         [Fact]
@@ -67,14 +67,14 @@ namespace Serilog.Settings.Configuration.Tests
 
             var result = _configurationReader.GetMethodCalls(JsonStringConfigSource.LoadSection(json, "WriteTo"));
 
-            Assert.Equal(1, result.Count);
+            Assert.Single(result);
             Assert.True(result.Contains("LiterateConsole"));
 
-            Assert.Equal(1, result["LiterateConsole"].Count());
+            Assert.Single(result["LiterateConsole"]);
 
             var args = result["LiterateConsole"].Single().ToArray();
 
-            Assert.Equal(1, args.Length);
+            Assert.Single(args);
             Assert.Equal("outputTemplate", args[0].Key);
             Assert.Equal("{Message}", args[0].Value.ConvertTo(typeof(string), new ResolutionContext()));
         }
@@ -114,8 +114,8 @@ namespace Serilog.Settings.Configuration.Tests
             Assert.True(result.Contains("DiagnosticTrace"));
             Assert.True(result.Contains("File"));
 
-            Assert.Equal(1, result["LiterateConsole"].Count());
-            Assert.Equal(1, result["DiagnosticTrace"].Count());
+            Assert.Single(result["LiterateConsole"]);
+            Assert.Single(result["DiagnosticTrace"]);
             Assert.Equal(2, result["File"].Count());
         }
 
@@ -133,9 +133,9 @@ namespace Serilog.Settings.Configuration.Tests
             Assert.True(result.Contains("WithMachineName"));
             Assert.True(result.Contains("WithThreadId"));
 
-            Assert.Equal(1, result["FromLogContext"].Count());
-            Assert.Equal(1, result["WithMachineName"].Count());
-            Assert.Equal(1, result["WithThreadId"].Count());
+            Assert.Single(result["FromLogContext"]);
+            Assert.Single(result["WithMachineName"]);
+            Assert.Single(result["WithThreadId"]);
         }
 
         [Fact]

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -38,7 +38,7 @@ namespace Serilog.Settings.Configuration.Tests
             LogEvent evt = null;
 
             var json = @"{
-                ""Serilog"": {            
+                ""Serilog"": {
                     ""Properties"": {
                         ""App"": ""Test""
                     }
@@ -58,23 +58,25 @@ namespace Serilog.Settings.Configuration.Tests
         [Theory]
         [InlineData("extended syntax",
             @"{
-                ""Serilog"": {            
+                ""Serilog"": {
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [
                         { ""Name"": ""DummyConsole""},
                         { ""Name"": ""DummyWithLevelSwitch""},
-                    ]        
+                    ]
                 }
             }")]
         [InlineData("simplified syntax",
             @"{
-                ""Serilog"": {            
+                ""Serilog"": {
                     ""Using"": [""TestDummies""],
-                    ""WriteTo"": [""DummyConsole"", ""DummyWithLevelSwitch"" ]        
+                    ""WriteTo"": [""DummyConsole"", ""DummyWithLevelSwitch"" ]
                 }
             }")]
         public void ParameterlessSinksAreConfigured(string syntax, string json)
         {
+            _ = syntax;
+
             var log = ConfigFromJson(json)
                 .CreateLogger();
 
@@ -83,15 +85,15 @@ namespace Serilog.Settings.Configuration.Tests
 
             log.Write(Some.InformationEvent());
 
-            Assert.Equal(1, DummyConsoleSink.Emitted.Count);
-            Assert.Equal(1, DummyWithLevelSwitchSink.Emitted.Count);
+            Assert.Single(DummyConsoleSink.Emitted);
+            Assert.Single(DummyWithLevelSwitchSink.Emitted);
         }
 
         [Fact]
         public void ConfigurationAssembliesFromDllScanning()
         {
             var json = @"{
-                ""Serilog"": {            
+                ""Serilog"": {
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [""DummyConsole""]
                 }
@@ -109,19 +111,19 @@ namespace Serilog.Settings.Configuration.Tests
 
             log.Write(Some.InformationEvent());
 
-            Assert.Equal(1, DummyConsoleSink.Emitted.Count);
+            Assert.Single(DummyConsoleSink.Emitted);
         }
 
         [Fact]
         public void SinksAreConfigured()
         {
             var json = @"{
-                ""Serilog"": {            
+                ""Serilog"": {
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [{
                         ""Name"": ""DummyRollingFile"",
                         ""Args"": {""pathFormat"" : ""C:\\""}
-                    }]        
+                    }]
                 }
             }";
 
@@ -133,20 +135,20 @@ namespace Serilog.Settings.Configuration.Tests
 
             log.Write(Some.InformationEvent());
 
-            Assert.Equal(1, DummyRollingFileSink.Emitted.Count);
-            Assert.Equal(0, DummyRollingFileAuditSink.Emitted.Count);
+            Assert.Single(DummyRollingFileSink.Emitted);
+            Assert.Empty(DummyRollingFileAuditSink.Emitted);
         }
 
         [Fact]
         public void AuditSinksAreConfigured()
         {
             var json = @"{
-                ""Serilog"": {            
+                ""Serilog"": {
                     ""Using"": [""TestDummies""],
                     ""AuditTo"": [{
                         ""Name"": ""DummyRollingFile"",
                         ""Args"": {""pathFormat"" : ""C:\\""}
-                    }]        
+                    }]
                 }
             }";
 
@@ -158,16 +160,16 @@ namespace Serilog.Settings.Configuration.Tests
 
             log.Write(Some.InformationEvent());
 
-            Assert.Equal(0, DummyRollingFileSink.Emitted.Count);
-            Assert.Equal(1, DummyRollingFileAuditSink.Emitted.Count);
+            Assert.Empty(DummyRollingFileSink.Emitted);
+            Assert.Single(DummyRollingFileAuditSink.Emitted);
         }
 
         [Fact]
         public void AuditToSubLoggersAreConfigured()
         {
             var json = @"{
-            ""Serilog"": {            
-                ""Using"": [""TestDummies""],       
+            ""Serilog"": {
+                ""Using"": [""TestDummies""],
                 ""AuditTo"": [{
                     ""Name"": ""Logger"",
                     ""Args"": {
@@ -177,7 +179,7 @@ namespace Serilog.Settings.Configuration.Tests
                                 ""Args"": {""pathFormat"" : ""C:\\""}
                             }]}
                     }
-                }]        
+                }]
             }
             }";
 
@@ -189,8 +191,8 @@ namespace Serilog.Settings.Configuration.Tests
 
             log.Write(Some.InformationEvent());
 
-            Assert.Equal(0, DummyRollingFileSink.Emitted.Count);
-            Assert.Equal(1, DummyRollingFileAuditSink.Emitted.Count);
+            Assert.Empty(DummyRollingFileSink.Emitted);
+            Assert.Single(DummyRollingFileAuditSink.Emitted);
         }
 
         [Fact]
@@ -202,7 +204,7 @@ namespace Serilog.Settings.Configuration.Tests
                         ""Override"" : {
                             ""System"" : ""Warning""
                         }
-                    }        
+                    }
                 }
             }";
 
@@ -236,7 +238,7 @@ namespace Serilog.Settings.Configuration.Tests
                             ""System"" : ""Warning"",
                             ""System.Threading"": ""Debug""
                         }
-                    }        
+                    }
                 }
             }";
 
@@ -252,23 +254,23 @@ namespace Serilog.Settings.Configuration.Tests
             var custom = log.ForContext(Constants.SourceContextPropertyName, typeof(System.Threading.Tasks.Task).FullName + "<42>");
             custom.Write(Some.DebugEvent());
             Assert.NotNull(evt);
-            
+
             evt = null;
             var systemThreadingLogger = log.ForContext<System.Threading.Tasks.Task>();
             systemThreadingLogger.Write(Some.DebugEvent());
-            Assert.NotNull(evt);              
+            Assert.NotNull(evt);
         }
 
         [Fact]
         public void SinksWithAbstractParamsAreConfiguredWithTypeName()
         {
             var json = @"{
-                ""Serilog"": {            
+                ""Serilog"": {
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [{
                         ""Name"": ""DummyConsole"",
                         ""Args"": {""theme"" : ""Serilog.Settings.Configuration.Tests.Support.CustomConsoleTheme, Serilog.Settings.Configuration.Tests""}
-                    }]        
+                    }]
                 }
             }";
 
@@ -285,12 +287,12 @@ namespace Serilog.Settings.Configuration.Tests
         public void SinksAreConfiguredWithStaticMember()
         {
             var json = @"{
-                ""Serilog"": {            
+                ""Serilog"": {
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [{
                         ""Name"": ""DummyConsole"",
                         ""Args"": {""theme"" : ""TestDummies.Console.Themes.ConsoleThemes::Theme1, TestDummies""}
-                    }]        
+                    }]
                 }
             }";
 
@@ -400,7 +402,7 @@ namespace Serilog.Settings.Configuration.Tests
         public void SettingMinimumLevelControlledByToAnUndeclaredSwitchThrows()
         {
             var json = @"{
-                ""Serilog"": {            
+                ""Serilog"": {
                     ""LevelSwitches"": {""$switch1"" : ""Warning"" },
                     ""MinimumLevel"" : {
                         ""ControlledBy"" : ""$switch2""
@@ -420,7 +422,7 @@ namespace Serilog.Settings.Configuration.Tests
         public void LoggingLevelSwitchIsPassedToSinks()
         {
             var json = @"{
-                ""Serilog"": {      
+                ""Serilog"": {
                     ""Using"": [""TestDummies""],
                     ""LevelSwitches"": {""$switch1"" : ""Information"" },
                     ""MinimumLevel"" : {
@@ -429,7 +431,7 @@ namespace Serilog.Settings.Configuration.Tests
                     ""WriteTo"": [{
                         ""Name"": ""DummyWithLevelSwitch"",
                         ""Args"": {""controlLevelSwitch"" : ""$switch1""}
-                    }]      
+                    }]
                 }
             }";
 
@@ -456,7 +458,7 @@ namespace Serilog.Settings.Configuration.Tests
         public void ReferencingAnUndeclaredSwitchInSinkThrows()
         {
             var json = @"{
-                ""Serilog"": {      
+                ""Serilog"": {
                     ""Using"": [""TestDummies""],
                     ""LevelSwitches"": {""$switch1"" : ""Information"" },
                     ""MinimumLevel"" : {
@@ -465,7 +467,7 @@ namespace Serilog.Settings.Configuration.Tests
                     ""WriteTo"": [{
                         ""Name"": ""DummyWithLevelSwitch"",
                         ""Args"": {""controlLevelSwitch"" : ""$switch2""}
-                    }]      
+                    }]
                 }
             }";
 
@@ -493,7 +495,7 @@ namespace Serilog.Settings.Configuration.Tests
                     ""WriteTo"": [{
                         ""Name"": ""DummyWithLevelSwitch"",
                         ""Args"": {""controlLevelSwitch"" : ""$specificSwitch""}
-                    }]     
+                    }]
                 }
             }";
 
@@ -532,12 +534,12 @@ namespace Serilog.Settings.Configuration.Tests
         public void SinkWithIConfigurationArguments()
         {
             var json = @"{
-                ""Serilog"": {            
+                ""Serilog"": {
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [{
                         ""Name"": ""DummyWithConfiguration"",
                         ""Args"": {}
-                    }]        
+                    }]
                 }
             }";
 
@@ -556,12 +558,12 @@ namespace Serilog.Settings.Configuration.Tests
         public void SinkWithOptionalIConfigurationArguments()
         {
             var json = @"{
-                ""Serilog"": {            
+                ""Serilog"": {
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [{
                         ""Name"": ""DummyWithOptionalConfiguration"",
                         ""Args"": {}
-                    }]        
+                    }]
                 }
             }";
 
@@ -580,12 +582,12 @@ namespace Serilog.Settings.Configuration.Tests
         public void SinkWithIConfigSectionArguments()
         {
             var json = @"{
-                ""Serilog"": {            
+                ""Serilog"": {
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [{
                         ""Name"": ""DummyWithConfigSection"",
                         ""Args"": {""configurationSection"" : { ""foo"" : ""bar"" } }
-                    }]        
+                    }]
                 }
             }";
 
@@ -604,13 +606,13 @@ namespace Serilog.Settings.Configuration.Tests
         public void SinkWithConfigurationBindingArgument()
         {
             var json = @"{
-                ""Serilog"": {            
+                ""Serilog"": {
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [{
                         ""Name"": ""DummyRollingFile"",
                         ""Args"": {""pathFormat"" : ""C:\\"",
                                    ""objectBinding"" : [ { ""foo"" : ""bar"" }, { ""abc"" : ""xyz"" } ] }
-                    }]        
+                    }]
                 }
             }";
 
@@ -621,20 +623,20 @@ namespace Serilog.Settings.Configuration.Tests
 
             log.Write(Some.InformationEvent());
 
-            Assert.Equal(1, DummyRollingFileSink.Emitted.Count);
+            Assert.Single(DummyRollingFileSink.Emitted);
         }
 
         [Fact]
         public void SinkWithStringArrayArgument()
         {
             var json = @"{
-                ""Serilog"": {            
+                ""Serilog"": {
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [{
                         ""Name"": ""DummyRollingFile"",
                         ""Args"": {""pathFormat"" : ""C:\\"",
                                    ""stringArrayBinding"" : [ ""foo"", ""bar"", ""baz"" ] }
-                    }]        
+                    }]
                 }
             }";
 
@@ -645,7 +647,7 @@ namespace Serilog.Settings.Configuration.Tests
 
             log.Write(Some.InformationEvent());
 
-            Assert.Equal(1, DummyRollingFileSink.Emitted.Count);
+            Assert.Single(DummyRollingFileSink.Emitted);
         }
 
         [Fact]
@@ -673,7 +675,7 @@ namespace Serilog.Settings.Configuration.Tests
                                 ""System.UInt32""
                             ]
                         }
-                    }]        
+                    }]
                 }
             }";
 
@@ -692,13 +694,13 @@ namespace Serilog.Settings.Configuration.Tests
         public void SinkWithIntArrayArgument()
         {
             var json = @"{
-                ""Serilog"": {            
+                ""Serilog"": {
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [{
                         ""Name"": ""DummyRollingFile"",
                         ""Args"": {""pathFormat"" : ""C:\\"",
                                    ""intArrayBinding"" : [ 1,2,3,4,5 ] }
-                    }]        
+                    }]
                 }
             }";
 
@@ -709,7 +711,7 @@ namespace Serilog.Settings.Configuration.Tests
 
             log.Write(Some.InformationEvent());
 
-            Assert.Equal(1, DummyRollingFileSink.Emitted.Count);
+            Assert.Single(DummyRollingFileSink.Emitted);
         }
 
         [Trait("Bugfix", "#111")]
@@ -717,12 +719,12 @@ namespace Serilog.Settings.Configuration.Tests
         public void CaseInsensitiveArgumentNameMatching()
         {
             var json = @"{
-                ""Serilog"": {            
+                ""Serilog"": {
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [{
                         ""Name"": ""DummyRollingFile"",
                         ""Args"": {""PATHFORMAT"" : ""C:\\""}
-                    }]        
+                    }]
                 }
             }";
 
@@ -733,7 +735,7 @@ namespace Serilog.Settings.Configuration.Tests
 
             log.Write(Some.InformationEvent());
 
-            Assert.Equal(1, DummyRollingFileSink.Emitted.Count);
+            Assert.Single(DummyRollingFileSink.Emitted);
         }
 
         [Trait("Bugfix", "#91")]
@@ -741,7 +743,7 @@ namespace Serilog.Settings.Configuration.Tests
         public void WriteToLoggerWithRestrictedToMinimumLevelIsSupported()
         {
             var json = @"{
-            ""Serilog"": {            
+            ""Serilog"": {
                 ""Using"": [""TestDummies""],
                 ""WriteTo"": [{
                     ""Name"": ""Logger"",
@@ -751,9 +753,9 @@ namespace Serilog.Settings.Configuration.Tests
                                 ""Name"": ""DummyRollingFile"",
                                 ""Args"": {""pathFormat"" : ""C:\\""}
                             }]},
-                        ""restrictedToMinimumLevel"": ""Warning"" 
+                        ""restrictedToMinimumLevel"": ""Warning""
                     }
-                }]        
+                }]
             }
             }";
 
@@ -765,7 +767,7 @@ namespace Serilog.Settings.Configuration.Tests
             log.Write(Some.InformationEvent());
             log.Write(Some.WarningEvent());
 
-            Assert.Equal(1, DummyRollingFileSink.Emitted.Count);
+            Assert.Single(DummyRollingFileSink.Emitted);
         }
 
         [Trait("Bugfix", "#91")]
@@ -773,9 +775,9 @@ namespace Serilog.Settings.Configuration.Tests
         public void WriteToSubLoggerWithLevelSwitchIsSupported()
         {
             var json = @"{
-            ""Serilog"": {            
+            ""Serilog"": {
                 ""Using"": [""TestDummies""],
-                ""LevelSwitches"": {""$switch1"" : ""Warning"" },          
+                ""LevelSwitches"": {""$switch1"" : ""Warning"" },
                 ""MinimumLevel"" : {
                         ""ControlledBy"" : ""$switch1""
                     },
@@ -788,7 +790,7 @@ namespace Serilog.Settings.Configuration.Tests
                                 ""Args"": {""pathFormat"" : ""C:\\""}
                             }]}
                     }
-                }]        
+                }]
             }
             }";
 
@@ -800,7 +802,7 @@ namespace Serilog.Settings.Configuration.Tests
             log.Write(Some.InformationEvent());
             log.Write(Some.WarningEvent());
 
-            Assert.Equal(1, DummyRollingFileSink.Emitted.Count);
+            Assert.Single(DummyRollingFileSink.Emitted);
         }
 
         [Trait("Bugfix", "#103")]
@@ -808,22 +810,22 @@ namespace Serilog.Settings.Configuration.Tests
         public void InconsistentComplexVsScalarArgumentValuesThrowsIOE()
         {
             var jsonDiscreteValue = @"{
-                ""Serilog"": {            
+                ""Serilog"": {
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [{
                         ""Name"": ""DummyRollingFile"",
                         ""Args"": {""pathFormat"" : ""C:\\""}
-                    }]        
+                    }]
                 }
             }";
 
             var jsonComplexValue = @"{
-                ""Serilog"": {            
+                ""Serilog"": {
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [{
                         ""Name"": ""DummyRollingFile"",
                         ""Args"": {""pathFormat"" : { ""foo"" : ""bar"" } }
-                    }]        
+                    }]
                 }
             }";
 

--- a/test/Serilog.Settings.Configuration.Tests/DllScanningAssemblyFinderTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/DllScanningAssemblyFinderTests.cs
@@ -1,4 +1,4 @@
-﻿#if PRIVATE_BIN
+﻿#if NETFRAMEWORK
 using System;
 using System.IO;
 #endif
@@ -22,7 +22,7 @@ namespace Serilog.Settings.Configuration.Tests
             Assert.Single(assemblyNames);
         }
 
-#if PRIVATE_BIN
+#if NETFRAMEWORK
         [Fact]
         public void ShouldProbePrivateBinPath()
         {

--- a/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
+++ b/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net50;netcoreapp3.1;netcoreapp2.1;net452</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Serilog.Settings.Configuration.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
@@ -9,10 +9,6 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net452'">
-    <DefineConstants>$(DefineConstants);PRIVATE_BIN</DefineConstants>
-  </PropertyGroup>
-  
   <ItemGroup>
     <None Include="*.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
@@ -24,26 +20,12 @@
     <ProjectReference Include="..\TestDummies\TestDummies.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.1.2" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.10" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net50'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-  </ItemGroup>
-
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="Serilog.Filters.Expressions" Version="2.0.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
-    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.2.0" />
+    <PackageReference Include="Serilog.Expressions" Version="3.3.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
+    <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 </Project>

--- a/test/TestDummies/DummyLoggerConfigurationExtensions.cs
+++ b/test/TestDummies/DummyLoggerConfigurationExtensions.cs
@@ -129,7 +129,9 @@ namespace TestDummies
             return LoggerSinkConfiguration.Wrap(
                 loggerSinkConfiguration,
                 s => new DummyWrappingSink(s),
-                wrappedSinkAction);
+                wrappedSinkAction,
+                LogEventLevel.Verbose,
+                levelSwitch: null);
         }
 
         public static LoggerConfiguration WithDummyHardCodedString(

--- a/test/TestDummies/TestDummies.csproj
+++ b/test/TestDummies/TestDummies.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <AssemblyName>TestDummies</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -9,17 +9,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.6.0" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="2.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="1.1.2" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
* Add .NET 6 target framework instead
* Update tests and sample dependencies
* Simplify conditional package references in all projects
* Remove the custom `PRIVATE_BIN` define, use the built-in `NETFRAMEWORK` instead
* Also use the Visual Studio 2022 image on AppVeyor because VS 2022 is required for the .NET 6 SDK
* Add a reference to `Microsoft.TestPlatform.ObjectModel` so that `dotnet test` also works on Linux and macOS for the .NET Framework targets
* Depend on Microsoft.Extensions.Configuration.Binder: there's no need to depend on Microsoft.Extensions.Options.ConfigurationExtensions, taking a dependency on Microsoft.Extensions.Configuration.Binder is enough for what Serilog.Settings.Configuration needs to do.