### PR TITLE
Fix ReSharper/Rider inspection warnings

### DIFF
--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 
 using Microsoft.Extensions.Configuration;

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ObjectArgumentValue.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ObjectArgumentValue.cs
@@ -88,12 +88,12 @@ namespace Serilog.Settings.Configuration
 
                 var configurationElements = _section.GetChildren().ToArray();
                 result = Activator.CreateInstance(toType);
-                
+
                 for (int i = 0; i < configurationElements.Length; ++i)
                 {
                     var argumentValue = ConfigurationReader.GetArgumentValue(configurationElements[i], _configurationAssemblies);
                     var value = argumentValue.ConvertTo(elementType, resolutionContext);
-                    addMethod.Invoke(result, new object[] { value });
+                    addMethod.Invoke(result, new[] { value });
                 }
 
                 return true;
@@ -164,7 +164,7 @@ namespace Serilog.Settings.Configuration
             {
                 return false;
             }
-            
+
             var ctorArguments = new List<Expression>();
             foreach (var argumentValue in ctor.ArgumentValues)
             {

--- a/test/Serilog.Settings.Configuration.Tests/LoggerConfigurationExtensionsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/LoggerConfigurationExtensionsTests.cs
@@ -24,7 +24,7 @@ namespace Serilog.Settings.Configuration.Tests
             LogEvent evt = null;
 
             var json = @"{
-		        ""NotSerilog"": {            
+		        ""NotSerilog"": {
 			        ""Properties"": {
 				        ""App"": ""Test""
 			        }
@@ -53,12 +53,12 @@ namespace Serilog.Settings.Configuration.Tests
         public void ReadFromConfigurationSectionThrowsWhenTryingToCallConfigurationMethodWithIConfigurationParam()
         {
             var json = @"{
-                ""NotSerilog"": {            
+                ""NotSerilog"": {
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [{
                         ""Name"": ""DummyWithConfiguration"",
                         ""Args"": {}
-                    }]        
+                    }]
                 }
             }";
 
@@ -84,12 +84,12 @@ namespace Serilog.Settings.Configuration.Tests
         public void ReadFromConfigurationDoesNotThrowWhenTryingToCallConfigurationMethodWithIConfigurationParam()
         {
             var json = @"{
-                ""NotSerilog"": {            
+                ""NotSerilog"": {
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [{
                         ""Name"": ""DummyWithConfiguration"",
                         ""Args"": {}
-                    }]        
+                    }]
                 }
             }";
 
@@ -97,7 +97,7 @@ namespace Serilog.Settings.Configuration.Tests
                 .AddJsonString(json)
                 .Build();
 
-            var exception = new LoggerConfiguration()
+            _ = new LoggerConfiguration()
                    .ReadFrom.Configuration(config, "NotSerilog")
                    .CreateLogger();
 
@@ -108,12 +108,12 @@ namespace Serilog.Settings.Configuration.Tests
         public void ReadFromConfigurationSectionDoesNotThrowWhenTryingToCallConfigurationMethodWithOptionalIConfigurationParam()
         {
             var json = @"{
-                ""NotSerilog"": {            
+                ""NotSerilog"": {
                     ""Using"": [""TestDummies""],
                     ""WriteTo"": [{
                         ""Name"": ""DummyWithOptionalConfiguration"",
                         ""Args"": {}
-                    }]        
+                    }]
                 }
             }";
 

--- a/test/TestDummies/DummyThreadIdEnricher.cs
+++ b/test/TestDummies/DummyThreadIdEnricher.cs
@@ -5,10 +5,6 @@ namespace TestDummies
 {
     public class DummyThreadIdEnricher : ILogEventEnricher
     {
-        static DummyThreadIdEnricher()
-        {
-        }
-
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
         {
             logEvent.AddPropertyIfAbsent(propertyFactory


### PR DESCRIPTION
The `serilog-settings-configuration.sln.DotSettings` file defines many custom inspection severities as error rendering the solution with many red squiggly lines when opened in Rider or in Visual Studio with ReSharper.