### PR TITLE
Using different versions of Microsoft.Extensions.DependencyModel base…

### DIFF
--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -26,7 +26,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <None Include="..\..\assets\icon.png" Pack="true" PackagePath="" />
   </ItemGroup>
@@ -38,4 +37,17 @@
   <ItemGroup Condition="$(TargetFramework) != 'net451'">
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.0" />
   </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net451' Or $(TargetFramework) == 'net461'">
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) != 'net451' And $(TargetFramework) != 'net461' And $(TargetFramework) != 'net7.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -5,7 +5,7 @@
     <VersionPrefix>3.5.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>netstandard2.0;net451;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net451;net461;net7.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Settings.Configuration</AssemblyName>

--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -5,7 +5,7 @@
     <VersionPrefix>3.5.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>netstandard2.0;net451;net461;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net451;net461</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Settings.Configuration</AssemblyName>
@@ -42,11 +42,7 @@
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework) != 'net451' And $(TargetFramework) != 'net461' And $(TargetFramework) != 'net7.0'">
+  <ItemGroup Condition="$(TargetFramework) != 'net451' And $(TargetFramework) != 'net461'">
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -5,7 +5,7 @@
     <VersionPrefix>3.5.0</VersionPrefix>
     <LangVersion>latest</LangVersion>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>netstandard2.0;net451;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net451;net461</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Settings.Configuration</AssemblyName>
@@ -42,7 +42,11 @@
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.0.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) != 'net451' And $(TargetFramework) != 'net461'">
+  <ItemGroup Condition="$(TargetFramework) == 'net7.0'">
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(TargetFramework) != 'net451' And $(TargetFramework) != 'net461' And $(TargetFramework) != 'net7.0'">
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
   </ItemGroup>
 

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -20,7 +20,7 @@ class ConfigurationReader : IConfigurationReader
     readonly IConfigurationSection _section;
     readonly IReadOnlyCollection<Assembly> _configurationAssemblies;
     readonly ResolutionContext _resolutionContext;
-#if NETSTANDARD || NET461
+#if !NET451
     readonly IConfigurationRoot _configurationRoot;
 #endif
 
@@ -29,7 +29,7 @@ class ConfigurationReader : IConfigurationReader
         _section = configSection ?? throw new ArgumentNullException(nameof(configSection));
         _configurationAssemblies = LoadConfigurationAssemblies(_section, assemblyFinder);
         _resolutionContext = new ResolutionContext(configuration);
-#if NETSTANDARD || NET461
+#if !NET451
         _configurationRoot = configuration as IConfigurationRoot;
 #endif
     }
@@ -40,7 +40,7 @@ class ConfigurationReader : IConfigurationReader
         _section = configSection ?? throw new ArgumentNullException(nameof(configSection));
         _configurationAssemblies = configurationAssemblies ?? throw new ArgumentNullException(nameof(configurationAssemblies));
         _resolutionContext = resolutionContext ?? throw new ArgumentNullException(nameof(resolutionContext));
-        #if NETSTANDARD || NET461
+        #if !NET451
         _configurationRoot = resolutionContext.HasAppConfiguration ? resolutionContext.AppConfiguration as IConfigurationRoot : null;
         #endif
     }
@@ -192,7 +192,7 @@ class ConfigurationReader : IConfigurationReader
 
         IConfigurationSection GetDefaultMinLevelDirective()
         {
-            #if NETSTANDARD || NET461
+            #if !NET451
 
             var defaultLevelDirective = minimumLevelDirective.GetSection("Default");
             if (_configurationRoot != null && minimumLevelDirective.Value != null && defaultLevelDirective.Value != null)

--- a/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
+++ b/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;netcoreapp3.1;net462</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Serilog.Settings.Configuration.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>

--- a/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
+++ b/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;net462;net7.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Serilog.Settings.Configuration.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>

--- a/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
+++ b/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net462;net7.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <AssemblyName>Serilog.Settings.Configuration.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>

--- a/test/TestDummies/TestDummies.csproj
+++ b/test/TestDummies/TestDummies.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462;net7.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <AssemblyName>TestDummies</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>

--- a/test/TestDummies/TestDummies.csproj
+++ b/test/TestDummies/TestDummies.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net462;net7.0</TargetFrameworks>
     <AssemblyName>TestDummies</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
Using different versions of `Microsoft.Extensions.DependencyModel` based on target framework. This resolves warnings when using package as part of solution where another package requires a more recent version of `Microsoft.Extensions.DependencyModel`.