### PR TITLE
Add a way to get the configured log level switches

### DIFF
--- a/src/Serilog.Settings.Configuration/ConfigurationLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Settings.Configuration/ConfigurationLoggerConfigurationExtensions.cs
@@ -48,6 +48,28 @@ public static class ConfigurationLoggerConfigurationExtensions
         string sectionName,
         DependencyContext dependencyContext = null)
     {
+        return Configuration(settingConfiguration, configuration, sectionName, out _, dependencyContext);
+    }
+
+    /// <summary>
+    /// Reads logger settings from the provided configuration object using the provided section name. Generally this
+    /// is preferable over the other method that takes a configuration section. Only this version will populate
+    /// IConfiguration parameters on target methods.
+    /// </summary>
+    /// <param name="settingConfiguration">Logger setting configuration.</param>
+    /// <param name="configuration">A configuration object which contains a Serilog section.</param>
+    /// <param name="sectionName">A section name for section which contains a Serilog section.</param>
+    /// <param name="loadedConfiguration">Contains information about the loaded configuration upon return.</param>
+    /// <param name="dependencyContext">The dependency context from which sink/enricher packages can be located. If not supplied, the platform
+    /// default will be used.</param>
+    /// <returns>An object allowing configuration to continue.</returns>
+    public static LoggerConfiguration Configuration(
+        this LoggerSettingsConfiguration settingConfiguration,
+        IConfiguration configuration,
+        string sectionName,
+        out LoadedConfiguration loadedConfiguration,
+        DependencyContext dependencyContext = null)
+    {
         if (settingConfiguration == null) throw new ArgumentNullException(nameof(settingConfiguration));
         if (configuration == null) throw new ArgumentNullException(nameof(configuration));
         if (sectionName == null) throw new ArgumentNullException(nameof(sectionName));
@@ -56,11 +78,10 @@ public static class ConfigurationLoggerConfigurationExtensions
             ? AssemblyFinder.Auto()
             : AssemblyFinder.ForDependencyContext(dependencyContext);
 
-        return settingConfiguration.Settings(
-            new ConfigurationReader(
-                configuration.GetSection(sectionName),
-                assemblyFinder,
-                configuration));
+        var configurationReader = new ConfigurationReader(configuration.GetSection(sectionName), assemblyFinder, configuration);
+        var loggerConfiguration = settingConfiguration.Settings(configurationReader);
+        loadedConfiguration = configurationReader.GetLoadedConfiguration();
+        return loggerConfiguration;
     }
 
     /// <summary>
@@ -78,6 +99,24 @@ public static class ConfigurationLoggerConfigurationExtensions
         IConfiguration configuration,
         DependencyContext dependencyContext = null)
         => Configuration(settingConfiguration, configuration, DefaultSectionName, dependencyContext);
+
+    /// <summary>
+    /// Reads logger settings from the provided configuration object using the default section name. Generally this
+    /// is preferable over the other method that takes a configuration section. Only this version will populate
+    /// IConfiguration parameters on target methods.
+    /// </summary>
+    /// <param name="settingConfiguration">Logger setting configuration.</param>
+    /// <param name="configuration">A configuration object which contains a Serilog section.</param>
+    /// <param name="loadedConfiguration">Contains information about the loaded configuration upon return.</param>
+    /// <param name="dependencyContext">The dependency context from which sink/enricher packages can be located. If not supplied, the platform
+    /// default will be used.</param>
+    /// <returns>An object allowing configuration to continue.</returns>
+    public static LoggerConfiguration Configuration(
+        this LoggerSettingsConfiguration settingConfiguration,
+        IConfiguration configuration,
+        out LoadedConfiguration loadedConfiguration,
+        DependencyContext dependencyContext = null)
+        => Configuration(settingConfiguration, configuration, DefaultSectionName, out loadedConfiguration, dependencyContext);
 
     /// <summary>
     /// Reads logger settings from the provided configuration section. Generally it is preferable to use the other
@@ -123,6 +162,25 @@ public static class ConfigurationLoggerConfigurationExtensions
         IConfiguration configuration,
         string sectionName,
         ConfigurationAssemblySource configurationAssemblySource)
+        => Configuration(settingConfiguration, configuration, sectionName, configurationAssemblySource, out _);
+
+    /// <summary>
+    /// Reads logger settings from the provided configuration object using the provided section name. Generally this
+    /// is preferable over the other method that takes a configuration section. Only this version will populate
+    /// IConfiguration parameters on target methods.
+    /// </summary>
+    /// <param name="settingConfiguration">Logger setting configuration.</param>
+    /// <param name="configuration">A configuration object which contains a Serilog section.</param>
+    /// <param name="sectionName">A section name for section which contains a Serilog section.</param>
+    /// <param name="configurationAssemblySource">Defines how the package identifies assemblies to scan for sinks and other types.</param>
+    /// <param name="loadedConfiguration">Contains information about the loaded configuration upon return.</param>
+    /// <returns>An object allowing configuration to continue.</returns>
+    public static LoggerConfiguration Configuration(
+        this LoggerSettingsConfiguration settingConfiguration,
+        IConfiguration configuration,
+        string sectionName,
+        ConfigurationAssemblySource configurationAssemblySource,
+        out LoadedConfiguration loadedConfiguration)
     {
         if (settingConfiguration == null) throw new ArgumentNullException(nameof(settingConfiguration));
         if (configuration == null) throw new ArgumentNullException(nameof(configuration));
@@ -130,7 +188,10 @@ public static class ConfigurationLoggerConfigurationExtensions
 
         var assemblyFinder = AssemblyFinder.ForSource(configurationAssemblySource);
 
-        return settingConfiguration.Settings(new ConfigurationReader(configuration.GetSection(sectionName), assemblyFinder, configuration));
+        var configurationReader = new ConfigurationReader(configuration.GetSection(sectionName), assemblyFinder, configuration);
+        var loggerConfiguration = settingConfiguration.Settings(configurationReader);
+        loadedConfiguration = configurationReader.GetLoadedConfiguration();
+        return loggerConfiguration;
     }
 
     /// <summary>
@@ -183,12 +244,32 @@ public static class ConfigurationLoggerConfigurationExtensions
         IConfiguration configuration,
         string sectionName,
         params Assembly[] assemblies)
+        => Configuration(settingConfiguration, configuration, sectionName, out _, assemblies);
+
+    /// <summary>
+    /// Reads logger settings from the provided configuration object using the provided section name.
+    /// </summary>
+    /// <param name="settingConfiguration">Logger setting configuration.</param>
+    /// <param name="configuration">A configuration object which contains a Serilog section.</param>
+    /// <param name="sectionName">A section name for section which contains a Serilog section.</param>
+    /// <param name="loadedConfiguration">Contains information about the loaded configuration upon return.</param>
+    /// <param name="assemblies">A collection of assemblies that contains sinks and other types.</param>
+    /// <returns>An object allowing configuration to continue.</returns>
+    public static LoggerConfiguration Configuration(
+        this LoggerSettingsConfiguration settingConfiguration,
+        IConfiguration configuration,
+        string sectionName,
+        out LoadedConfiguration loadedConfiguration,
+        params Assembly[] assemblies)
     {
         if (settingConfiguration == null) throw new ArgumentNullException(nameof(settingConfiguration));
         if (configuration == null) throw new ArgumentNullException(nameof(configuration));
         if (sectionName == null) throw new ArgumentNullException(nameof(sectionName));
 
-        return settingConfiguration.Settings(new ConfigurationReader(configuration.GetSection(sectionName), assemblies, new ResolutionContext(configuration)));
+        var configurationReader = new ConfigurationReader(configuration.GetSection(sectionName), assemblies, new ResolutionContext(configuration));
+        var loggerConfiguration = settingConfiguration.Settings(configurationReader);
+        loadedConfiguration = configurationReader.GetLoadedConfiguration();
+        return loggerConfiguration;
     }
 
     /// <summary>

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -58,6 +58,11 @@ class ConfigurationReader : IConfigurationReader
         ApplyAuditSinks(loggerConfiguration);
     }
 
+    public LoadedConfiguration GetLoadedConfiguration()
+    {
+        return new LoadedConfiguration(_resolutionContext.LogLevelSwitches);
+    }
+
     void ProcessFilterSwitchDeclarations()
     {
         var filterSwitchesDirective = _section.GetSection("FilterSwitches");

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/LoadedConfiguration.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/LoadedConfiguration.cs
@@ -15,6 +15,6 @@ public class LoadedConfiguration
     /// <summary>
     /// The log level switches that were loaded from the <c>LevelSwitches</c> section of the configuration.
     /// </summary>
-    /// <remarks>The keys of the dictionary are the name of the switches, including the leading <c>$</c> character.</remarks>
+    /// <remarks>The keys of the dictionary are the names of the switches, including the leading <c>$</c> character.</remarks>
     public IReadOnlyDictionary<string, LoggingLevelSwitch> LogLevelSwitches { get; }
 }

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/LoadedConfiguration.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/LoadedConfiguration.cs
@@ -7,16 +7,14 @@ namespace Serilog.Settings.Configuration;
 /// </summary>
 public class LoadedConfiguration
 {
-    readonly IDictionary<string, LoggingLevelSwitch> _logLevelSwitches;
-
-    internal LoadedConfiguration(IDictionary<string, LoggingLevelSwitch> logLevelSwitches)
+    internal LoadedConfiguration(IReadOnlyDictionary<string, LoggingLevelSwitch> logLevelSwitches)
     {
-        _logLevelSwitches = logLevelSwitches;
+        LogLevelSwitches = logLevelSwitches;
     }
 
     /// <summary>
     /// The log level switches that were loaded from the <c>LevelSwitches</c> section of the configuration.
     /// </summary>
-    /// <remarks>The keys of the dictionary are the name of the switches without the leading <c>$</c> character.</remarks>
-    public IReadOnlyDictionary<string, LoggingLevelSwitch> LogLevelSwitches => _logLevelSwitches.ToDictionary(e => e.Key.TrimStart('$'), e => e.Value);
+    /// <remarks>The keys of the dictionary are the name of the switches, including the leading <c>$</c> character.</remarks>
+    public IReadOnlyDictionary<string, LoggingLevelSwitch> LogLevelSwitches { get; }
 }

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/LoadedConfiguration.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/LoadedConfiguration.cs
@@ -1,0 +1,22 @@
+using Serilog.Core;
+
+namespace Serilog.Settings.Configuration;
+
+/// <summary>
+/// Contains information about the loaded configuration.
+/// </summary>
+public class LoadedConfiguration
+{
+    readonly IDictionary<string,LoggingLevelSwitch> _logLevelSwitches;
+
+    internal LoadedConfiguration(IDictionary<string, LoggingLevelSwitch> logLevelSwitches)
+    {
+        _logLevelSwitches = logLevelSwitches;
+    }
+
+    /// <summary>
+    /// The log level switches that were loaded from the <c>LevelSwitches</c> section of the configuration.
+    /// </summary>
+    /// <remarks>The keys of the dictionary are the name of the switches without the leading <c>$</c> character.</remarks>
+    public IReadOnlyDictionary<string, LoggingLevelSwitch> LogLevelSwitches => _logLevelSwitches.ToDictionary(e => e.Key.TrimStart('$'), e => e.Value);
+}

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/LoadedConfiguration.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/LoadedConfiguration.cs
@@ -7,7 +7,7 @@ namespace Serilog.Settings.Configuration;
 /// </summary>
 public class LoadedConfiguration
 {
-    readonly IDictionary<string,LoggingLevelSwitch> _logLevelSwitches;
+    readonly IDictionary<string, LoggingLevelSwitch> _logLevelSwitches;
 
     internal LoadedConfiguration(IDictionary<string, LoggingLevelSwitch> logLevelSwitches)
     {

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ResolutionContext.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ResolutionContext.cs
@@ -9,8 +9,8 @@ namespace Serilog.Settings.Configuration;
 /// </summary>
 sealed class ResolutionContext
 {
-    readonly IDictionary<string, LoggingLevelSwitch> _declaredLevelSwitches;
-    readonly IDictionary<string, LoggingFilterSwitchProxy> _declaredFilterSwitches;
+    readonly Dictionary<string, LoggingLevelSwitch> _declaredLevelSwitches;
+    readonly Dictionary<string, LoggingFilterSwitchProxy> _declaredFilterSwitches;
     readonly IConfiguration _appConfiguration;
 
     public ResolutionContext(IConfiguration appConfiguration = null)
@@ -20,7 +20,7 @@ sealed class ResolutionContext
         _appConfiguration = appConfiguration;
     }
 
-    public IDictionary<string, LoggingLevelSwitch> LogLevelSwitches => _declaredLevelSwitches;
+    public IReadOnlyDictionary<string, LoggingLevelSwitch> LogLevelSwitches => _declaredLevelSwitches;
 
     /// <summary>
     /// Looks up a switch in the declared LoggingLevelSwitches

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ResolutionContext.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ResolutionContext.cs
@@ -20,6 +20,8 @@ sealed class ResolutionContext
         _appConfiguration = appConfiguration;
     }
 
+    public IDictionary<string, LoggingLevelSwitch> LogLevelSwitches => _declaredLevelSwitches;
+
     /// <summary>
     /// Looks up a switch in the declared LoggingLevelSwitches
     /// </summary>

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -393,8 +393,8 @@ public class ConfigurationSettingsTests
             .WriteTo.Sink(new DelegatingSink(e => evt = e))
             .CreateLogger();
 
-        Assert.Contains("switch1", loadedConfiguration.LogLevelSwitches);
-        Assert.Equal(LogEventLevel.Warning, loadedConfiguration.LogLevelSwitches["switch1"].MinimumLevel);
+        Assert.Contains("$switch1", loadedConfiguration.LogLevelSwitches);
+        Assert.Equal(LogEventLevel.Warning, loadedConfiguration.LogLevelSwitches["$switch1"].MinimumLevel);
         log.Write(Some.DebugEvent());
         Assert.True(evt is null, "LoggingLevelSwitch initial level was Warning. It should not log Debug messages");
         log.Write(Some.InformationEvent());

--- a/test/Serilog.Settings.Configuration.Tests/DynamicLevelChangeTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/DynamicLevelChangeTests.cs
@@ -47,8 +47,10 @@ public class DynamicLevelChangeTests
     {
         using var logger = new LoggerConfiguration()
             .ReadFrom
-            .Configuration(new ConfigurationBuilder().Add(_configSource).Build())
+            .Configuration(new ConfigurationBuilder().Add(_configSource).Build(), out var loadedConfiguration)
             .CreateLogger();
+
+        Assert.Equal(LogEventLevel.Information, loadedConfiguration.LogLevelSwitches["mySwitch"].MinimumLevel);
 
         DummyConsoleSink.Emitted.Clear();
         logger.Write(Some.DebugEvent());
@@ -64,6 +66,7 @@ public class DynamicLevelChangeTests
         logger.Write(Some.DebugEvent());
         logger.ForContext(Constants.SourceContextPropertyName, "Root.Test").Write(Some.DebugEvent());
         Assert.Single(DummyConsoleSink.Emitted);
+        Assert.Equal(LogEventLevel.Debug, loadedConfiguration.LogLevelSwitches["mySwitch"].MinimumLevel);
 
         DummyConsoleSink.Emitted.Clear();
         UpdateConfig(overrideLevel: LogEventLevel.Debug);

--- a/test/Serilog.Settings.Configuration.Tests/DynamicLevelChangeTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/DynamicLevelChangeTests.cs
@@ -50,7 +50,7 @@ public class DynamicLevelChangeTests
             .Configuration(new ConfigurationBuilder().Add(_configSource).Build(), out var loadedConfiguration)
             .CreateLogger();
 
-        Assert.Equal(LogEventLevel.Information, loadedConfiguration.LogLevelSwitches["mySwitch"].MinimumLevel);
+        Assert.Equal(LogEventLevel.Information, loadedConfiguration.LogLevelSwitches["$mySwitch"].MinimumLevel);
 
         DummyConsoleSink.Emitted.Clear();
         logger.Write(Some.DebugEvent());
@@ -66,7 +66,7 @@ public class DynamicLevelChangeTests
         logger.Write(Some.DebugEvent());
         logger.ForContext(Constants.SourceContextPropertyName, "Root.Test").Write(Some.DebugEvent());
         Assert.Single(DummyConsoleSink.Emitted);
-        Assert.Equal(LogEventLevel.Debug, loadedConfiguration.LogLevelSwitches["mySwitch"].MinimumLevel);
+        Assert.Equal(LogEventLevel.Debug, loadedConfiguration.LogLevelSwitches["$mySwitch"].MinimumLevel);
 
         DummyConsoleSink.Emitted.Clear();
         UpdateConfig(overrideLevel: LogEventLevel.Debug);


### PR DESCRIPTION
I have created this pull request as a draft because a few things should be discussed before merging.

1. I chose `LoadedConfiguration` for the class holding the loaded log level switches, as proposed by @tsimbalar in https://github.com/serilog/serilog-settings-configuration/issues/206#issuecomment-643762537 I'm not convinced it's the best name and I'm happy to change it to something better.
2. This `LoadedConfiguration` class could also expose the log filter switches, although not the internal `LoggingFilterSwitchProxy` class directly. Maybe through a public `ILoggingFilterSwitch` interface with a single `Expression { get; set; }` property?

I am looking forward to your feedback.

Fixes #206