### PR TITLE
Add support for IFormatProvider used to convert string to other types

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,9 @@ Root section name can be changed:
 ```
 
 ```csharp
+var options = new ConfigurationReaderOptions { SectionName = "CustomSection" };
 var logger = new LoggerConfiguration()
-    .ReadFrom.Configuration(configuration, sectionName: "CustomSection")
+    .ReadFrom.Configuration(configuration, options)
     .CreateLogger();
 ```
 
@@ -106,8 +107,9 @@ In case of [non-standard](#azure-functions-v2-v3) dependency management you can 
 ```csharp
 var functionDependencyContext = DependencyContext.Load(typeof(Startup).Assembly);
 
+var options = new ConfigurationReaderOptions(functionDependencyContext) { SectionName = "AzureFunctionsJobHost:Serilog" };
 var logger = new LoggerConfiguration()
-    .ReadFrom.Configuration(hostConfig, sectionName: "AzureFunctionsJobHost:Serilog", dependencyContext: functionDependencyContext)
+    .ReadFrom.Configuration(hostConfig, options)
     .CreateLogger();
 ```
 
@@ -119,8 +121,9 @@ var configurationAssemblies = new[]
     typeof(ConsoleLoggerConfigurationExtensions).Assembly,
     typeof(FileLoggerConfigurationExtensions).Assembly,
 };
+var options = new ConfigurationReaderOptions(configurationAssemblies);
 var logger = new LoggerConfiguration()
-    .ReadFrom.Configuration(configuration, configurationAssemblies)
+    .ReadFrom.Configuration(configuration, options)
     .CreateLogger();
 ```
 
@@ -282,6 +285,8 @@ Some Serilog packages require a reference to a logger configuration object. The 
 
 When the configuration specifies a discrete value for a parameter (such as a string literal), the package will attempt to convert that value to the target method's declared CLR type of the parameter. Additional explicit handling is provided for parsing strings to `Uri`, `TimeSpan`, `enum`, arrays and custom collections.
 
+Since version 4.0.0, conversion will use the invariant culture (`CultureInfo.InvariantCulture`) as long as the `ReadFrom.Configuration(IConfiguration configuration, ConfigurationReaderOptions options)` method is used. Obsolete methods use the current culture to preserve backward compatibility.
+
 ### Static member support
 
 Static member access can be used for passing to the configuration argument via [special](https://github.com/serilog/serilog-settings-configuration/blob/dev/test/Serilog.Settings.Configuration.Tests/StringArgumentValueTests.cs#L35) syntax:
@@ -377,8 +382,9 @@ public class Startup : FunctionsStartup
             var functionDependencyContext = DependencyContext.Load(typeof(Startup).Assembly);
 
             var hostConfig = sp.GetRequiredService<IConfiguration>();
+            var options = new ConfigurationReaderOptions(functionDependencyContext) { SectionName = "AzureFunctionsJobHost:Serilog" };
             var logger = new LoggerConfiguration()
-                .ReadFrom.Configuration(hostConfig, sectionName: "AzureFunctionsJobHost:Serilog", dependencyContext: functionDependencyContext)
+                .ReadFrom.Configuration(hostConfig, options)
                 .CreateLogger();
 
             return new SerilogLoggerProvider(logger, dispose: true);

--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
+    <PackageReference Include="PolySharp" Version="1.12.1" PrivateAssets="All" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <None Include="..\..\assets\icon.png" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -22,11 +22,11 @@ class ConfigurationReader : IConfigurationReader
     readonly ResolutionContext _resolutionContext;
     readonly IConfigurationRoot _configurationRoot;
 
-    public ConfigurationReader(IConfigurationSection configSection, AssemblyFinder assemblyFinder, IConfiguration configuration = null)
+    public ConfigurationReader(IConfigurationSection configSection, AssemblyFinder assemblyFinder, IFormatProvider formatProvider, IConfiguration configuration = null)
     {
         _section = configSection ?? throw new ArgumentNullException(nameof(configSection));
         _configurationAssemblies = LoadConfigurationAssemblies(_section, assemblyFinder);
-        _resolutionContext = new ResolutionContext(configuration);
+        _resolutionContext = new ResolutionContext(configuration, formatProvider);
         _configurationRoot = configuration as IConfigurationRoot;
     }
 

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReaderOptions.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReaderOptions.cs
@@ -1,0 +1,62 @@
+using System.Globalization;
+using System.Reflection;
+using Microsoft.Extensions.DependencyModel;
+
+namespace Serilog.Settings.Configuration;
+
+/// <summary>
+/// Options to adjust how the configuration object is processed.
+/// </summary>
+public sealed class ConfigurationReaderOptions
+{
+    /// <summary>
+    /// Initialize a new instance of the <see cref="ConfigurationReaderOptions"/> class.
+    /// </summary>
+    /// <param name="assemblies">A collection of assemblies that contains sinks and other types.</param>
+    /// <exception cref="ArgumentNullException">The <paramref name="assemblies"/> argument is null.</exception>
+    /// <exception cref="ArgumentException">The <paramref name="assemblies"/> argument is empty.</exception>
+    public ConfigurationReaderOptions(params Assembly[] assemblies)
+    {
+        Assemblies = assemblies ?? throw new ArgumentNullException(nameof(assemblies));
+        if (assemblies.Length == 0)
+            throw new ArgumentException("The assemblies array must not be empty.", nameof(assemblies));
+    }
+
+    /// <summary>
+    /// Initialize a new instance of the <see cref="ConfigurationReaderOptions"/> class.
+    /// </summary>
+    /// <remarks>Prefer the constructor taking explicit assemblies: <see cref="ConfigurationReaderOptions(System.Reflection.Assembly[])"/>. It's the only one supporting single-file publishing.</remarks>
+    public ConfigurationReaderOptions() : this(dependencyContext: null)
+    {
+    }
+
+    /// <summary>
+    /// Initialize a new instance of the <see cref="ConfigurationReaderOptions"/> class.
+    /// </summary>
+    /// <param name="dependencyContext">
+    /// The dependency context from which sink/enricher packages can be located. If <see langword="null"/>, the platform default will be used.
+    /// </param>
+    /// <remarks>Prefer the constructor taking explicit assemblies: <see cref="ConfigurationReaderOptions(System.Reflection.Assembly[])"/>. It's the only one supporting single-file publishing.</remarks>
+    public ConfigurationReaderOptions(DependencyContext dependencyContext) => DependencyContext = dependencyContext;
+
+    /// <summary>
+    /// Initialize a new instance of the <see cref="ConfigurationReaderOptions"/> class.
+    /// </summary>
+    /// <param name="configurationAssemblySource">Defines how the package identifies assemblies to scan for sinks and other types.</param>
+    /// <remarks>Prefer the constructor taking explicit assemblies: <see cref="ConfigurationReaderOptions(System.Reflection.Assembly[])"/>. It's the only one supporting single-file publishing.</remarks>
+    public ConfigurationReaderOptions(ConfigurationAssemblySource configurationAssemblySource) => ConfigurationAssemblySource = configurationAssemblySource;
+
+    /// <summary>
+    /// The section name for section which contains a Serilog section. Defaults to <c>Serilog</c>.
+    /// </summary>
+    public string SectionName { get; init; } = ConfigurationLoggerConfigurationExtensions.DefaultSectionName;
+
+    /// <summary>
+    /// The <see cref="IFormatProvider"/> used when converting strings to other object types. Defaults to the invariant culture.
+    /// </summary>
+    public IFormatProvider FormatProvider { get; init; } = CultureInfo.InvariantCulture;
+
+    internal Assembly[] Assemblies { get; }
+    internal DependencyContext DependencyContext { get; }
+    internal ConfigurationAssemblySource? ConfigurationAssemblySource { get; }
+}

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ResolutionContext.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ResolutionContext.cs
@@ -13,12 +13,15 @@ sealed class ResolutionContext
     readonly IDictionary<string, LoggingFilterSwitchProxy> _declaredFilterSwitches;
     readonly IConfiguration _appConfiguration;
 
-    public ResolutionContext(IConfiguration appConfiguration = null)
+    public ResolutionContext(IConfiguration appConfiguration = null, IFormatProvider formatProvider = null)
     {
         _declaredLevelSwitches = new Dictionary<string, LoggingLevelSwitch>();
         _declaredFilterSwitches = new Dictionary<string, LoggingFilterSwitchProxy>();
         _appConfiguration = appConfiguration;
+        FormatProvider = formatProvider;
     }
+
+    public IFormatProvider FormatProvider { get; }
 
     /// <summary>
     /// Looks up a switch in the declared LoggingLevelSwitches

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/StringArgumentValue.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/StringArgumentValue.cs
@@ -155,7 +155,7 @@ class StringArgumentValue : IConfigurationArgumentValue
             }
         }
 
-        return Convert.ChangeType(argumentValue, toType);
+        return Convert.ChangeType(argumentValue, toType, resolutionContext.FormatProvider);
     }
 
     internal static Type FindType(string typeName)

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Globalization;
+using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Serilog.Events;
 using Serilog.Formatting;
@@ -16,7 +17,8 @@ public class ConfigurationReaderTests
     {
         _configurationReader = new ConfigurationReader(
             JsonStringConfigSource.LoadSection(@"{ 'Serilog': {  } }", "Serilog"),
-            AssemblyFinder.ForSource(ConfigurationAssemblySource.UseLoadedAssemblies));
+            AssemblyFinder.ForSource(ConfigurationAssemblySource.UseLoadedAssemblies),
+            CultureInfo.InvariantCulture);
     }
 
     [Fact]
@@ -190,7 +192,7 @@ public class ConfigurationReaderTests
     [MemberData(nameof(FlatMinimumLevel))]
     public void FlatMinimumLevelCorrectOneIsEnabledOnLogger(IConfigurationRoot root, LogEventLevel expectedMinimumLevel)
     {
-        var reader = new ConfigurationReader(root.GetSection("Serilog"), AssemblyFinder.ForSource(ConfigurationAssemblySource.UseLoadedAssemblies), root);
+        var reader = new ConfigurationReader(root.GetSection("Serilog"), AssemblyFinder.ForSource(ConfigurationAssemblySource.UseLoadedAssemblies), CultureInfo.InvariantCulture, root);
         var loggerConfig = new LoggerConfiguration();
 
         reader.Configure(loggerConfig);
@@ -214,7 +216,7 @@ public class ConfigurationReaderTests
     [MemberData(nameof(ObjectMinimumLevel))]
     public void ObjectMinimumLevelCorrectOneIsEnabledOnLogger(IConfigurationRoot root, LogEventLevel expectedMinimumLevel)
     {
-        var reader = new ConfigurationReader(root.GetSection("Serilog"), AssemblyFinder.ForSource(ConfigurationAssemblySource.UseLoadedAssemblies), root);
+        var reader = new ConfigurationReader(root.GetSection("Serilog"), AssemblyFinder.ForSource(ConfigurationAssemblySource.UseLoadedAssemblies), CultureInfo.InvariantCulture, root);
         var loggerConfig = new LoggerConfiguration();
 
         reader.Configure(loggerConfig);
@@ -256,7 +258,7 @@ public class ConfigurationReaderTests
     [MemberData(nameof(MixedMinimumLevel))]
     public void MixedMinimumLevelCorrectOneIsEnabledOnLogger(IConfigurationRoot root, LogEventLevel expectedMinimumLevel)
     {
-        var reader = new ConfigurationReader(root.GetSection("Serilog"), AssemblyFinder.ForSource(ConfigurationAssemblySource.UseLoadedAssemblies), root);
+        var reader = new ConfigurationReader(root.GetSection("Serilog"), AssemblyFinder.ForSource(ConfigurationAssemblySource.UseLoadedAssemblies), CultureInfo.InvariantCulture, root);
         var loggerConfig = new LoggerConfiguration();
 
         reader.Configure(loggerConfig);
@@ -268,7 +270,7 @@ public class ConfigurationReaderTests
     public void NoConfigurationRootUsedStillValid()
     {
         var section = JsonStringConfigSource.LoadSection(@"{ 'Nest': { 'Serilog': { 'MinimumLevel': 'Error' } } }", "Nest");
-        var reader = new ConfigurationReader(section.GetSection("Serilog"), AssemblyFinder.ForSource(ConfigurationAssemblySource.UseLoadedAssemblies), section);
+        var reader = new ConfigurationReader(section.GetSection("Serilog"), AssemblyFinder.ForSource(ConfigurationAssemblySource.UseLoadedAssemblies), CultureInfo.InvariantCulture, section);
         var loggerConfig = new LoggerConfiguration();
 
         reader.Configure(loggerConfig);

--- a/test/Serilog.Settings.Configuration.Tests/LoggerConfigurationExtensionsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/LoggerConfigurationExtensionsTests.cs
@@ -96,7 +96,7 @@ public class LoggerConfigurationExtensionsTests
             .Build();
 
         _ = new LoggerConfiguration()
-               .ReadFrom.Configuration(config, "NotSerilog")
+               .ReadFrom.Configuration(config, new ConfigurationReaderOptions { SectionName = "NotSerilog" })
                .CreateLogger();
 
     }

--- a/test/TestDummies/DummyLoggerConfigurationExtensions.cs
+++ b/test/TestDummies/DummyLoggerConfigurationExtensions.cs
@@ -156,4 +156,17 @@ public static class DummyLoggerConfigurationExtensions
             CustomStrings = customString,
         });
     }
+
+    public static LoggerConfiguration DummyNumbers(this LoggerDestructuringConfiguration loggerSinkConfiguration,
+        float floatValue,
+        double doubleValue,
+        decimal decimalValue)
+    {
+        return loggerSinkConfiguration.With(DummyPolicy.Current = new DummyPolicy
+        {
+            Float = floatValue,
+            Double = doubleValue,
+            Decimal = decimalValue,
+        });
+    }
 }

--- a/test/TestDummies/DummyPolicy.cs
+++ b/test/TestDummies/DummyPolicy.cs
@@ -18,6 +18,12 @@ public class DummyPolicy : IDestructuringPolicy
 
     public Type Type { get; set; }
 
+    public float Float { get; set; }
+
+    public double Double { get; set; }
+
+    public decimal Decimal { get; set; }
+
     public bool TryDestructure(object value, ILogEventPropertyValueFactory propertyValueFactory, out LogEventPropertyValue result)
     {
         result = null;


### PR DESCRIPTION
Also introduce a new `ConfigurationContext` class to avoid `ReadFrom.Configuration()` methods exponential growth when adding new options.

All _older_ `Configuration()` methods go through the newly introduced `Configuration(LoggerSettingsConfiguration, IConfiguration, ConfigurationContext)` method that takes an `ConfigurationContext` instance.

Older methods explicitly set the `FormatProvider` option to `null` in order to preserve backward compatibility.

By using the new `Configuration()` method, users opt into the new default of having the invariant culture as the format provider.

Note: the `= null` default value in the `Configuration()` method taking a `DependencyContext` has been removed in order to make sure the CS0121 compilation does not occur:

> [CS0121] The call is ambiguous between the following methods or properties: 'ConfigurationLoggerConfigurationExtensions.Configuration(LoggerSettingsConfiguration, IConfiguration, DependencyContext)' and 'ConfigurationLoggerConfigurationExtensions.Configuration(LoggerSettingsConfiguration, IConfiguration, ConfigurationContext)'

Fixes #325