### PR TITLE
Drop support for .NET Framework 4.5.1

### DIFF
--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -4,7 +4,7 @@
     <Description>Microsoft.Extensions.Configuration (appsettings.json) support for Serilog.</Description>
     <VersionPrefix>3.5.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>netstandard2.0;net451;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Settings.Configuration</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
@@ -21,17 +21,15 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Using Remove="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <None Include="..\..\assets\icon.png" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
-  <ItemGroup Condition="$(TargetFramework) == 'net451'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="1.1.2" />
-  </ItemGroup>
-
-  <ItemGroup Condition="$(TargetFramework) != 'net451'">
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="2.0.0" />
-  </ItemGroup>
 </Project>

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -20,18 +20,14 @@ class ConfigurationReader : IConfigurationReader
     readonly IConfigurationSection _section;
     readonly IReadOnlyCollection<Assembly> _configurationAssemblies;
     readonly ResolutionContext _resolutionContext;
-#if NETSTANDARD || NET461
     readonly IConfigurationRoot _configurationRoot;
-#endif
 
     public ConfigurationReader(IConfigurationSection configSection, AssemblyFinder assemblyFinder, IConfiguration configuration = null)
     {
         _section = configSection ?? throw new ArgumentNullException(nameof(configSection));
         _configurationAssemblies = LoadConfigurationAssemblies(_section, assemblyFinder);
         _resolutionContext = new ResolutionContext(configuration);
-#if NETSTANDARD || NET461
         _configurationRoot = configuration as IConfigurationRoot;
-#endif
     }
 
     // Used internally for processing nested configuration sections -- see GetMethodCalls below.
@@ -40,9 +36,7 @@ class ConfigurationReader : IConfigurationReader
         _section = configSection ?? throw new ArgumentNullException(nameof(configSection));
         _configurationAssemblies = configurationAssemblies ?? throw new ArgumentNullException(nameof(configurationAssemblies));
         _resolutionContext = resolutionContext ?? throw new ArgumentNullException(nameof(resolutionContext));
-        #if NETSTANDARD || NET461
         _configurationRoot = resolutionContext.HasAppConfiguration ? resolutionContext.AppConfiguration as IConfigurationRoot : null;
-        #endif
     }
 
     public void Configure(LoggerConfiguration loggerConfiguration)
@@ -192,8 +186,6 @@ class ConfigurationReader : IConfigurationReader
 
         IConfigurationSection GetDefaultMinLevelDirective()
         {
-            #if NETSTANDARD || NET461
-
             var defaultLevelDirective = minimumLevelDirective.GetSection("Default");
             if (_configurationRoot != null && minimumLevelDirective.Value != null && defaultLevelDirective.Value != null)
             {
@@ -212,8 +204,6 @@ class ConfigurationReader : IConfigurationReader
 
                 return null;
             }
-
-            #endif //NET451 or fallback
 
             return minimumLevelDirective.Value != null ? minimumLevelDirective : minimumLevelDirective.GetSection("Default");
         }

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
@@ -222,8 +222,6 @@ public class ConfigurationReaderTests
         AssertLogEventLevels(loggerConfig, expectedMinimumLevel);
     }
 
-    #if !(NET452)
-
     // currently only works in the .NET 4.6.1 and .NET Standard builds of Serilog.Settings.Configuration
     public static IEnumerable<object[]> MixedMinimumLevel => new List<object[]>
     {
@@ -265,8 +263,6 @@ public class ConfigurationReaderTests
 
         AssertLogEventLevels(loggerConfig, expectedMinimumLevel);
     }
-
-    #endif
 
     [Fact]
     public void NoConfigurationRootUsedStillValid()


### PR DESCRIPTION
Support for .NET Framework 4, 4.5, and 4.5.1 [ended on January 12, 2016](https://learn.microsoft.com/en-GB/lifecycle/faq/dotnet-framework), that was 7 years ago!

Also bump Microsoft.Extensions.Configuration.Binder and Microsoft.Extensions.DependencyModel to version 6.0.0 since version 2.0.0 and 3.0.0 respectively have been deprecated as part of the [.NET Package Deprecation effort](https://github.com/dotnet/announcements/issues/217).

Finally, this change allows to remove all conditional compilation.

Note that removing a target framework is a breaking change so it will require a major version bump, i.e. 4.0.0.