### PR TITLE
Fix some nullable reference type issues

### DIFF
--- a/src/Serilog.Settings.Configuration/Settings/Configuration/Assemblies/AssemblyFinder.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/Assemblies/AssemblyFinder.cs
@@ -7,7 +7,7 @@ abstract class AssemblyFinder
 {
     public abstract IReadOnlyList<AssemblyName> FindAssembliesContainingName(string nameToFind);
 
-    protected static bool IsCaseInsensitiveMatch(string text, string textToFind)
+    protected static bool IsCaseInsensitiveMatch(string? text, string textToFind)
     {
         return text != null && text.ToLowerInvariant().Contains(textToFind.ToLowerInvariant());
     }

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -413,7 +413,7 @@ class ConfigurationReader : IConfigurationReader
            || paramInfo.ParameterType == typeof(IConfiguration);
     }
 
-    object GetImplicitValueForNotSpecifiedKey(ParameterInfo parameter, MethodInfo methodToInvoke)
+    object? GetImplicitValueForNotSpecifiedKey(ParameterInfo parameter, MethodInfo methodToInvoke)
     {
         if (!HasImplicitValueWhenNotSpecified(parameter))
         {

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/StringArgumentValue.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/StringArgumentValue.cs
@@ -173,7 +173,7 @@ class StringArgumentValue : IConfigurationArgumentValue
         return type;
     }
 
-    internal static bool TryParseStaticMemberAccessor(string input, [NotNullWhen(true)] out string? accessorTypeName, [NotNullWhen(true)] out string? memberName)
+    internal static bool TryParseStaticMemberAccessor(string? input, [NotNullWhen(true)] out string? accessorTypeName, [NotNullWhen(true)] out string? memberName)
     {
         if (input == null)
         {

--- a/test/Serilog.Settings.Configuration.Tests/ObjectArgumentValueTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ObjectArgumentValueTests.cs
@@ -29,7 +29,7 @@ public class ObjectArgumentValueTests
         var testSection = _config.GetSection(caseSection);
 
         Assert.True(ObjectArgumentValue.TryBuildCtorExpression(testSection, targetType, new(), out var ctorExpression));
-        Assert.Equal(expectedExpression, ctorExpression?.ToString());
+        Assert.Equal(expectedExpression, ctorExpression.ToString());
     }
 
     class A

--- a/test/Serilog.Settings.Configuration.Tests/StringArgumentValueTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/StringArgumentValueTests.cs
@@ -53,7 +53,7 @@ public class StringArgumentValueTests
     // a full-qualified type name should not be considered a static member accessor
     [InlineData("My.NameSpace.Class, MyAssembly, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
        null, null)]
-    public void TryParseStaticMemberAccessorReturnsExpectedResults(string input, string expectedAccessorType, string expectedPropertyName)
+    public void TryParseStaticMemberAccessorReturnsExpectedResults(string input, string? expectedAccessorType, string expectedPropertyName)
     {
         var actual = StringArgumentValue.TryParseStaticMemberAccessor(input,
             out var actualAccessorType,


### PR DESCRIPTION
Not sure why they did not show up as warnings then as errors (since TreatWarningsAsErrors is true)