### PR TITLE
Make all JSON strings valid in tests

### DIFF
--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
@@ -1,4 +1,3 @@
-using System.Globalization;
 using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Serilog.Events;
@@ -16,7 +15,7 @@ public class ConfigurationReaderTests
     public ConfigurationReaderTests()
     {
         _configurationReader = new ConfigurationReader(
-            JsonStringConfigSource.LoadSection("{ 'Serilog': {  } }", "Serilog"),
+            JsonStringConfigSource.LoadSection("{ \"Serilog\": {  } }", "Serilog"),
             AssemblyFinder.ForSource(ConfigurationAssemblySource.UseLoadedAssemblies),
             new ConfigurationReaderOptions());
     }
@@ -26,7 +25,7 @@ public class ConfigurationReaderTests
     {
         var json = """
         {
-            'WriteTo': [ 'LiterateConsole', 'DiagnosticTrace' ]
+            "WriteTo": [ "LiterateConsole", "DiagnosticTrace" ]
         }
         """;
 
@@ -44,8 +43,8 @@ public class ConfigurationReaderTests
     {
         var json = """
         {
-            'WriteTo': [ {
-                'Name': 'LiterateConsole'
+            "WriteTo": [ {
+                "Name": "LiterateConsole"
             }]
         }
         """;
@@ -62,10 +61,10 @@ public class ConfigurationReaderTests
     {
         var json = """
         {
-            'WriteTo': [ {
-                'Name': 'LiterateConsole',
-                'Args': {
-                    'outputTemplate': '{Message}'
+            "WriteTo": [ {
+                "Name": "LiterateConsole",
+                "Args": {
+                    "outputTemplate": "{Message}"
                 },
             }]
         }
@@ -90,25 +89,25 @@ public class ConfigurationReaderTests
     {
         var json = """
         {
-            'WriteTo': [
+            "WriteTo": [
               {
-                'Name': 'LiterateConsole',
-                'Args': {
-                    'outputTemplate': '{Message}'
+                "Name": "LiterateConsole",
+                "Args": {
+                    "outputTemplate": "{Message}"
                   },
               },
-              'DiagnosticTrace'
+              "DiagnosticTrace"
             ],
-            'WriteTo:File1': {
-                'Name': 'File',
-                'Args': {
-                    'outputTemplate': '{Message}'
+            "WriteTo:File1": {
+                "Name": "File",
+                "Args": {
+                    "outputTemplate": "{Message}"
                 },
             },
-            'WriteTo:File2': {
-                'Name': 'File',
-                'Args': {
-                    'outputTemplate': '{Message}'
+            "WriteTo:File2": {
+                "Name": "File",
+                "Args": {
+                    "outputTemplate": "{Message}"
                 },
             }
         }
@@ -131,7 +130,7 @@ public class ConfigurationReaderTests
     {
         var json = """
         {
-            'Enrich': [ 'FromLogContext', 'WithMachineName', 'WithThreadId' ]
+            "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ]
         }
         """;
 
@@ -274,7 +273,17 @@ public class ConfigurationReaderTests
     [Fact]
     public void NoConfigurationRootUsedStillValid()
     {
-        var section = JsonStringConfigSource.LoadSection("{ 'Nest': { 'Serilog': { 'MinimumLevel': 'Error' } } }", "Nest");
+        var json = """
+        {
+            "Nest": {
+                "Serilog": {
+                    "MinimumLevel": "Error"
+                }
+            }
+        }
+        """;
+
+        var section = JsonStringConfigSource.LoadSection(json, "Nest");
         var reader = new ConfigurationReader(section.GetSection("Serilog"), AssemblyFinder.ForSource(ConfigurationAssemblySource.UseLoadedAssemblies), new ConfigurationReaderOptions(), section);
         var loggerConfig = new LoggerConfiguration();
 

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
@@ -23,6 +23,7 @@ public class ConfigurationReaderTests
     [Fact]
     public void WriteToSupportSimplifiedSyntax()
     {
+        // language=json
         var json = """
         {
             "WriteTo": [ "LiterateConsole", "DiagnosticTrace" ]
@@ -41,6 +42,7 @@ public class ConfigurationReaderTests
     [Fact]
     public void WriteToSupportExpandedSyntaxWithoutArgs()
     {
+        // language=json
         var json = """
         {
             "WriteTo": [ {
@@ -59,13 +61,14 @@ public class ConfigurationReaderTests
     [Fact]
     public void WriteToSupportExpandedSyntaxWithArgs()
     {
+        // language=json
         var json = """
         {
             "WriteTo": [ {
                 "Name": "LiterateConsole",
                 "Args": {
                     "outputTemplate": "{Message}"
-                },
+                }
             }]
         }
         """;
@@ -87,6 +90,7 @@ public class ConfigurationReaderTests
     [Fact]
     public void WriteToSupportMultipleSinksOfTheSameKind()
     {
+        // language=json
         var json = """
         {
             "WriteTo": [
@@ -94,7 +98,7 @@ public class ConfigurationReaderTests
                 "Name": "LiterateConsole",
                 "Args": {
                     "outputTemplate": "{Message}"
-                  },
+                  }
               },
               "DiagnosticTrace"
             ],
@@ -102,13 +106,13 @@ public class ConfigurationReaderTests
                 "Name": "File",
                 "Args": {
                     "outputTemplate": "{Message}"
-                },
+                }
             },
             "WriteTo:File2": {
                 "Name": "File",
                 "Args": {
                     "outputTemplate": "{Message}"
-                },
+                }
             }
         }
         """;
@@ -128,6 +132,7 @@ public class ConfigurationReaderTests
     [Fact]
     public void Enrich_SupportSimplifiedSyntax()
     {
+        // language=json
         var json = """
         {
             "Enrich": [ "FromLogContext", "WithMachineName", "WithThreadId" ]
@@ -273,6 +278,7 @@ public class ConfigurationReaderTests
     [Fact]
     public void NoConfigurationRootUsedStillValid()
     {
+        // language=json
         var json = """
         {
             "Nest": {

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -395,12 +395,12 @@ public class ConfigurationSettingsTests
     {
         var json = $$"""
             {
-                'Serilog': {
-                    'FilterSwitches': { '{{switchName}}': 'Prop = 42' },
-                    'Filter:BySwitch': {
-                        'Name': 'ControlledBy',
-                        'Args': {
-                            'switch': '$mySwitch'
+                "Serilog": {
+                    "FilterSwitches": { "{{switchName}}": "Prop = 42" },
+                    "Filter:BySwitch": {
+                        "Name": "ControlledBy",
+                        "Args": {
+                            "switch": "$mySwitch"
                         }
                     }
                 }
@@ -426,10 +426,10 @@ public class ConfigurationSettingsTests
     {
         var json = $$"""
             {
-                'Serilog': {
-                    'LevelSwitches': { '{{switchName}}' : 'Warning' },
-                    'MinimumLevel' : {
-                        'ControlledBy' : '$switch1'
+                "Serilog": {
+                    "LevelSwitches": { "{{switchName}}" : "Warning" },
+                    "MinimumLevel" : {
+                        "ControlledBy" : "$switch1"
                     }
                 }
             }
@@ -1379,12 +1379,12 @@ public class ConfigurationSettingsTests
     {
         var json = $$"""
             {
-                'Serilog': {
-                    'LevelSwitches': { '{{switchName}}': 'Information' },
-                    'MinimumLevel': {
-                        'Override': {
-                            'System': 'Warning',
-                            'System.Threading': 'Debug'
+                "Serilog": {
+                    "LevelSwitches": { "{{switchName}}": "Information" },
+                    "MinimumLevel": {
+                        "Override": {
+                            "System": "Warning",
+                            "System.Threading": "Debug"
                         }
                     }
                 }

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -36,6 +36,7 @@ public class ConfigurationSettingsTests
     {
         LogEvent? evt = null;
 
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -63,6 +64,7 @@ public class ConfigurationSettingsTests
     {
         LogEvent? evt = null;
 
+        // language=json
         var json = """
             {
                 "Properties": {
@@ -120,6 +122,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void ConfigurationAssembliesFromDllScanning()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -147,6 +150,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void SinksAreConfigured()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -174,6 +178,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void AuditSinksAreConfigured()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -201,6 +206,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void AuditToSubLoggersAreConfigured()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -234,6 +240,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void TestMinimumLevelOverrides()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -268,6 +275,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void TestMinimumLevelOverridesForChildContext()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -304,6 +312,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void SinksWithAbstractParamsAreConfiguredWithTypeName()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -328,6 +337,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void SinksAreConfiguredWithStaticMember()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -373,6 +383,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void LoggingLevelSwitchWithInvalidNameThrowsFormatException()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -393,6 +404,7 @@ public class ConfigurationSettingsTests
     [InlineData("mySwitch")]
     public void LoggingFilterSwitchIsConfigured(string switchName)
     {
+        // language=json
         var json = $$"""
             {
                 "Serilog": {
@@ -424,6 +436,7 @@ public class ConfigurationSettingsTests
     [InlineData("switch1")]
     public void LoggingLevelSwitchIsConfigured(string switchName)
     {
+        // language=json
         var json = $$"""
             {
                 "Serilog": {
@@ -451,6 +464,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void SettingMinimumLevelControlledByToAnUndeclaredSwitchThrows()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -473,6 +487,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void LoggingLevelSwitchIsPassedToSinks()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -511,6 +526,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void ReferencingAnUndeclaredSwitchInSinkThrows()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -538,6 +554,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void LoggingLevelSwitchCanBeUsedForMinimumLevelOverrides()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -592,6 +609,7 @@ public class ConfigurationSettingsTests
     [Trait("BugFix", "https://github.com/serilog/serilog-settings-configuration/issues/142")]
     public void SinkWithIConfigurationArguments()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -618,6 +636,7 @@ public class ConfigurationSettingsTests
     [Trait("BugFix", "https://github.com/serilog/serilog-settings-configuration/issues/142")]
     public void SinkWithOptionalIConfigurationArguments()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -644,6 +663,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void SinkWithIConfigSectionArguments()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -670,6 +690,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void SinkWithConfigurationBindingArgument()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -696,6 +717,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void SinkWithStringArrayArgument()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -734,6 +756,7 @@ public class ConfigurationSettingsTests
 
         try
         {
+            // language=json
             var json = """
             {
                 "Serilog": {
@@ -768,6 +791,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void DestructureWithCollectionsOfTypeArgument()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -811,6 +835,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void SinkWithIntArrayArgument()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -838,6 +863,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void CaseInsensitiveArgumentNameMatching()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -864,6 +890,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void WriteToLoggerWithRestrictedToMinimumLevelIsSupported()
     {
+        // language=json
         var json = """
         {
             "Serilog": {
@@ -898,6 +925,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void WriteToSubLoggerWithLevelSwitchIsSupported()
     {
+        // language=json
         var json = """
         {
             "Serilog": {
@@ -935,6 +963,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void InconsistentComplexVsScalarArgumentValuesThrowsIOE()
     {
+        // language=json
         var jsonDiscreteValue = """
             {
                 "Serilog": {
@@ -947,6 +976,7 @@ public class ConfigurationSettingsTests
             }
             """;
 
+        // language=json
         var jsonComplexValue = """
             {
                 "Serilog": {
@@ -976,6 +1006,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void DestructureLimitsNestingDepth()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -1011,6 +1042,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void DestructureLimitsStringLength()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -1032,6 +1064,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void DestructureLimitsCollectionCount()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -1065,6 +1098,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void DestructuringWithCustomExtensionMethodIsApplied()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -1091,6 +1125,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void DestructuringAsScalarIsAppliedWithShortTypeName()
     {
+        // language=json
         var json = """
             {
                 "Serilog": {
@@ -1117,6 +1152,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void DestructuringAsScalarIsAppliedWithAssemblyQualifiedName()
     {
+        // language=json
         var json = $$"""
             {
                 "Serilog": {
@@ -1143,6 +1179,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void WriteToSinkIsAppliedWithCustomSink()
     {
+        // language=json
         var json = $$"""
             {
                 "Serilog": {
@@ -1170,6 +1207,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void WriteToSinkIsAppliedWithCustomSinkAndMinimumLevel()
     {
+        // language=json
         var json = $$"""
             {
                 "Serilog": {
@@ -1199,6 +1237,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void WriteToSinkIsAppliedWithCustomSinkAndLevelSwitch()
     {
+        // language=json
         var json = $$"""
             {
                 "Serilog": {
@@ -1229,6 +1268,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void AuditToSinkIsAppliedWithCustomSink()
     {
+        // language=json
         var json = $$"""
             {
                 "Serilog": {
@@ -1256,6 +1296,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void AuditToSinkIsAppliedWithCustomSinkAndMinimumLevel()
     {
+        // language=json
         var json = $$"""
             {
                 "Serilog": {
@@ -1285,6 +1326,7 @@ public class ConfigurationSettingsTests
     [Fact]
     public void AuditToSinkIsAppliedWithCustomSinkAndLevelSwitch()
     {
+        // language=json
         var json = $$"""
             {
                 "Serilog": {
@@ -1317,6 +1359,7 @@ public class ConfigurationSettingsTests
     {
         LogEvent? evt = null;
 
+        // language=json
         var json = $$"""
             {
                 "Serilog": {
@@ -1347,6 +1390,7 @@ public class ConfigurationSettingsTests
     {
         LogEvent? evt = null;
 
+        // language=json
         var json = $$"""
             {
                 "Serilog": {
@@ -1377,6 +1421,7 @@ public class ConfigurationSettingsTests
     [InlineData("switch1")]
     public void TestLogLevelSwitchesCallback(string switchName)
     {
+        // language=json
         var json = $$"""
             {
                 "Serilog": {

--- a/test/Serilog.Settings.Configuration.Tests/DynamicLevelChangeTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/DynamicLevelChangeTests.cs
@@ -9,6 +9,7 @@ namespace Serilog.Settings.Configuration.Tests;
 
 public class DynamicLevelChangeTests
 {
+    // language=json
     const string DefaultConfig = """
         {
             "Serilog": {

--- a/test/Serilog.Settings.Configuration.Tests/DynamicLevelChangeTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/DynamicLevelChangeTests.cs
@@ -11,26 +11,26 @@ public class DynamicLevelChangeTests
 {
     const string DefaultConfig = """
         {
-            'Serilog': {
-                'Using': [ 'TestDummies' ],
-                'MinimumLevel': {
-                    'Default': 'Information',
-                    'Override': {
-                        'Root.Test': 'Information'
+            "Serilog": {
+                "Using": [ "TestDummies" ],
+                "MinimumLevel": {
+                    "Default": "Information",
+                    "Override": {
+                        "Root.Test": "Information"
                     }
                 },
-                'LevelSwitches': { '$mySwitch': 'Information' },
-                'FilterSwitches': { '$myFilter': null },
-                'Filter:Dummy': {
-                    'Name': 'ControlledBy',
-                    'Args': {
-                        'switch': '$myFilter'
+                "LevelSwitches": { "$mySwitch": "Information" },
+                "FilterSwitches": { "$myFilter": null },
+                "Filter:Dummy": {
+                    "Name": "ControlledBy",
+                    "Args": {
+                        "switch": "$myFilter"
                     }
                 },
-                'WriteTo:Dummy': {
-                    'Name': 'DummyConsole',
-                    'Args': {
-                        'levelSwitch': '$mySwitch'
+                "WriteTo:Dummy": {
+                    "Name": "DummyConsole",
+                    "Args": {
+                        "levelSwitch": "$mySwitch"
                     }
                 }
             }

--- a/test/Serilog.Settings.Configuration.Tests/LoggerConfigurationExtensionsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/LoggerConfigurationExtensionsTests.cs
@@ -21,6 +21,7 @@ public class LoggerConfigurationExtensionsTests
     {
         LogEvent? evt = null;
 
+        // language=json
         var json = """
             {
                 "NotSerilog": {
@@ -52,6 +53,7 @@ public class LoggerConfigurationExtensionsTests
     [Trait("BugFix", "https://github.com/serilog/serilog-settings-configuration/issues/143")]
     public void ReadFromConfigurationSectionThrowsWhenTryingToCallConfigurationMethodWithIConfigurationParam()
     {
+        // language=json
         var json = """
             {
                 "NotSerilog": {
@@ -85,6 +87,7 @@ public class LoggerConfigurationExtensionsTests
     [Fact]
     public void ReadFromConfigurationDoesNotThrowWhenTryingToCallConfigurationMethodWithIConfigurationParam()
     {
+        // language=json
         var json = """
             {
                 "NotSerilog": {
@@ -111,6 +114,7 @@ public class LoggerConfigurationExtensionsTests
     [Trait("BugFix", "https://github.com/serilog/serilog-settings-configuration/issues/143")]
     public void ReadFromConfigurationSectionDoesNotThrowWhenTryingToCallConfigurationMethodWithOptionalIConfigurationParam()
     {
+        // language=json
         var json = """
             {
                 "NotSerilog": {

--- a/test/Serilog.Settings.Configuration.Tests/Support/ConfigurationReaderTestHelpers.cs
+++ b/test/Serilog.Settings.Configuration.Tests/Support/ConfigurationReaderTestHelpers.cs
@@ -7,16 +7,16 @@ static class ConfigurationReaderTestHelpers
 {
     public const string minimumLevelFlatTemplate = """
     {{
-        'Serilog': {{
-            'MinimumLevel': '{0}'
+        "Serilog": {{
+            "MinimumLevel": "{0}"
         }}
     }}
     """;
     public const string minimumLevelObjectTemplate = """
     {{
-        'Serilog': {{
-            'MinimumLevel': {{
-                'Default': '{0}'
+        "Serilog": {{
+            "MinimumLevel": {{
+                "Default": "{0}"
             }}
         }}
     }}

--- a/test/Serilog.Settings.Configuration.Tests/Support/Extensions.cs
+++ b/test/Serilog.Settings.Configuration.Tests/Support/Extensions.cs
@@ -9,11 +9,5 @@ public static class Extensions
         return ((ScalarValue)@this).Value;
     }
 
-    public static string ToValidJson(this string str)
-    {
-        str = str.Replace('\'', '"');
-        return str;
-    }
-
     public static string Format(this string template, params object[] paramObjects) => string.Format(template, paramObjects);
 }

--- a/test/Serilog.Settings.Configuration.Tests/Support/JsonStringConfigSource.cs
+++ b/test/Serilog.Settings.Configuration.Tests/Support/JsonStringConfigSource.cs
@@ -42,7 +42,7 @@ class JsonStringConfigSource : IConfigurationSource
 
         public override void Load()
         {
-            Load(StringToStream(_json.ToValidJson()));
+            Load(StringToStream(_json));
         }
 
         static Stream StringToStream(string str)


### PR DESCRIPTION
So that we can get rid of the `ToValidJson` extension method.

Now that raw string literals have been introduced (in #354) having valid _readable_ JSON in strings for tests becomes easy. There is no need to escape quotes anymore with either `\"` or `""`.

This will also make it easier for newcomers to understand the tests at first glance. I had my WTF moment when I first saw JSON with single quotes. 🤔