### PR TITLE
Improve SelfLog when a configuration method is not found

### DIFF
--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -470,8 +470,15 @@ class ConfigurationReader : IConfigurationReader
                 .ToList();
 
             if (!methodsByName.Any())
-                SelfLog.WriteLine($"Unable to find a method called {name}. Candidate methods are:{Environment.NewLine}{string.Join(Environment.NewLine, candidateMethods)}");
+            {
+                SelfLog.WriteLine($"Unable to find a method called {name}.");
+                if (candidateMethods.Any())
+                {
+                    SelfLog.WriteLine($"Candidate methods are:{Environment.NewLine}{string.Join(Environment.NewLine, candidateMethods)}");
+                }
+            }
             else
+            {
                 SelfLog.WriteLine($"Unable to find a method called {name} "
                 + (suppliedArgumentNames.Any()
                     ? "for supplied arguments: " + string.Join(", ", suppliedArgumentNames)
@@ -479,8 +486,8 @@ class ConfigurationReader : IConfigurationReader
                 + ". Candidate methods are:"
                 + Environment.NewLine
                 + string.Join(Environment.NewLine, methodsByName));
+            }
         }
-
         return selectedMethod;
     }
 

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -471,10 +471,13 @@ class ConfigurationReader : IConfigurationReader
 
             if (!methodsByName.Any())
             {
-                SelfLog.WriteLine($"Unable to find a method called {name}.");
                 if (candidateMethods.Any())
                 {
-                    SelfLog.WriteLine($"Candidate methods are:{Environment.NewLine}{string.Join(Environment.NewLine, candidateMethods)}");
+                    SelfLog.WriteLine($"Unable to find a method called {name}. Candidate methods are:{Environment.NewLine}{string.Join(Environment.NewLine, candidateMethods)}");
+                }
+                else
+                {
+                    SelfLog.WriteLine($"Unable to find a method called {name}. No candidates found.");
                 }
             }
             else


### PR DESCRIPTION
List candidate methods only if there are any. Discovered this weird log while working on #353:
> Unable to find a method called WithThreadName. Candidate methods are: