### PR TITLE
Added missing closing bracket on Complex parameter value binding summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ If the parameter value is not a discrete value, it will try to find a best match
       // `type` (or $type) is optional, must be specified for abstract declared parameter types
       "type": "Serilog.Templates.ExpressionTemplate, Serilog.Expressions",
       "template": "[{@t:HH:mm:ss} {@l:u3} {Coalesce(SourceContext, '<none>')}] {@m}\n{@x}"
+      }
   }
 }
 ```


### PR DESCRIPTION
Fix on the sample that wouldn't allow code to run by just copying it