### PR TITLE
v7.0 - pin to MEC v7, including matching target frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,3 +428,7 @@ In order to make auto-discovery of configuration assemblies work, modify Functio
 
 </Project>
 ```
+
+### Versioning
+
+This package tracks the versioning and target framework support of its [_Microsoft.Extensions.Configuration_](https://nuget.org/packages/Microsoft.Extensions.Configuration) dependency.

--- a/sample/Sample/CustomFilter.cs
+++ b/sample/Sample/CustomFilter.cs
@@ -1,0 +1,21 @@
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Sample;
+
+// The filter syntax in the sample configuration file is
+// processed by the Serilog.Filters.Expressions package.
+public class CustomFilter : ILogEventFilter
+{
+    readonly LogEventLevel _levelFilter;
+
+    public CustomFilter(LogEventLevel levelFilter = LogEventLevel.Information)
+    {
+        _levelFilter = levelFilter;
+    }
+
+    public bool IsEnabled(LogEvent logEvent)
+    {
+        return logEvent.Level >= _levelFilter;
+    }
+}

--- a/sample/Sample/CustomPolicy.cs
+++ b/sample/Sample/CustomPolicy.cs
@@ -1,0 +1,24 @@
+using System.Diagnostics.CodeAnalysis;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Sample;
+
+public class CustomPolicy : IDestructuringPolicy
+{
+    public bool TryDestructure(object value, ILogEventPropertyValueFactory propertyValueFactory, [NotNullWhen(true)] out LogEventPropertyValue? result)
+    {
+        result = null;
+
+        if (value is LoginData loginData)
+        {
+            result = new StructureValue(
+                new List<LogEventProperty>
+                {
+                    new("Username", new ScalarValue(loginData.Username))
+                });
+        }
+
+        return (result != null);
+    }
+}

--- a/sample/Sample/LoginData.cs
+++ b/sample/Sample/LoginData.cs
@@ -1,0 +1,8 @@
+namespace Sample;
+
+public class LoginData
+{
+    public string? Username;
+    // ReSharper disable once NotAccessedField.Global
+    public string? Password;
+}

--- a/sample/Sample/Program.cs
+++ b/sample/Sample/Program.cs
@@ -1,98 +1,46 @@
 ﻿using Microsoft.Extensions.Configuration;
-
+using Sample;
 using Serilog;
 using Serilog.Core;
-using Serilog.Events;
 using Serilog.Debugging;
 
 // ReSharper disable UnusedType.Global
 
-namespace Sample;
+SelfLog.Enable(Console.Error);
 
-public class Program
+Thread.CurrentThread.Name = "Main thread";
+
+var configuration = new ConfigurationBuilder()
+    .SetBasePath(Directory.GetCurrentDirectory())
+    .AddJsonFile(path: "appsettings.json", optional: false, reloadOnChange: true)
+    .Build();
+
+var logger = new LoggerConfiguration()
+    .ReadFrom.Configuration(configuration)
+    .CreateLogger();
+
+logger.Information("Args: {Args}", args);
+
+do
 {
-    public static void Main(string[] args)
-    {
-        SelfLog.Enable(Console.Error);
+    logger.ForContext<Program>().Information("Hello, world!");
+    logger.ForContext<Program>().Error("Hello, world!");
+    logger.ForContext(Constants.SourceContextPropertyName, "Microsoft").Warning("Hello, world!");
+    logger.ForContext(Constants.SourceContextPropertyName, "Microsoft").Error("Hello, world!");
+    logger.ForContext(Constants.SourceContextPropertyName, "MyApp.Something.Tricky").Verbose("Hello, world!");
 
-        Thread.CurrentThread.Name = "Main thread";
+    logger.Information("Destructure with max object nesting depth:\n{@NestedObject}",
+        new { FiveDeep = new { Two = new { Three = new { Four = new { Five = "the end" } } } } });
 
-        var configuration = new ConfigurationBuilder()
-            .SetBasePath(Directory.GetCurrentDirectory())
-            .AddJsonFile(path: "appsettings.json", optional: false, reloadOnChange: true)
-            .Build();
+    logger.Information("Destructure with max string length:\n{@LongString}",
+        new { TwentyChars = "0123456789abcdefghij" });
 
-        var logger = new LoggerConfiguration()
-            .ReadFrom.Configuration(configuration)
-            .CreateLogger();
+    logger.Information("Destructure with max collection count:\n{@BigData}",
+        new { TenItems = new[] { "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten" } });
 
-        logger.Information("Args: {Args}", args);
+    logger.Information("Destructure with policy to strip password:\n{@LoginData}",
+        new LoginData { Username = "BGates", Password = "isityearoflinuxyet" });
 
-        do
-        {
-            logger.ForContext<Program>().Information("Hello, world!");
-            logger.ForContext<Program>().Error("Hello, world!");
-            logger.ForContext(Constants.SourceContextPropertyName, "Microsoft").Warning("Hello, world!");
-            logger.ForContext(Constants.SourceContextPropertyName, "Microsoft").Error("Hello, world!");
-            logger.ForContext(Constants.SourceContextPropertyName, "MyApp.Something.Tricky").Verbose("Hello, world!");
-
-            logger.Information("Destructure with max object nesting depth:\n{@NestedObject}",
-                new { FiveDeep = new { Two = new { Three = new { Four = new { Five = "the end" } } } } });
-
-            logger.Information("Destructure with max string length:\n{@LongString}",
-                new { TwentyChars = "0123456789abcdefghij" });
-
-            logger.Information("Destructure with max collection count:\n{@BigData}",
-                new { TenItems = new[] { "one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "ten" } });
-
-            logger.Information("Destructure with policy to strip password:\n{@LoginData}",
-                new LoginData { Username = "BGates", Password = "isityearoflinuxyet" });
-
-            Console.WriteLine("\nPress \"q\" to quit, or any other key to run again.\n");
-        }
-        while (!args.Contains("--run-once") && (Console.ReadKey().KeyChar != 'q'));
-    }
+    Console.WriteLine("\nPress \"q\" to quit, or any other key to run again.\n");
 }
-
-// The filter syntax in the sample configuration file is
-// processed by the Serilog.Filters.Expressions package.
-public class CustomFilter : ILogEventFilter
-{
-    readonly LogEventLevel _levelFilter;
-
-    public CustomFilter(LogEventLevel levelFilter = LogEventLevel.Information)
-    {
-        _levelFilter = levelFilter;
-    }
-
-    public bool IsEnabled(LogEvent logEvent)
-    {
-        return logEvent.Level >= _levelFilter;
-    }
-}
-
-public class LoginData
-{
-    public string? Username;
-    // ReSharper disable once NotAccessedField.Global
-    public string? Password;
-}
-
-public class CustomPolicy : IDestructuringPolicy
-{
-    public bool TryDestructure(object value, ILogEventPropertyValueFactory propertyValueFactory, out LogEventPropertyValue? result)
-    {
-        result = null;
-
-        if (value is LoginData loginData)
-        {
-            result = new StructureValue(
-                new List<LogEventProperty>
-                {
-                    new("Username", new ScalarValue(loginData.Username))
-                });
-        }
-
-        return (result != null);
-    }
-}
+while (!args.Contains("--run-once") && (Console.ReadKey().KeyChar != 'q'));

--- a/sample/Sample/Sample.csproj
+++ b/sample/Sample/Sample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netcoreapp3.1;net462</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net462</TargetFrameworks>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
@@ -22,6 +22,7 @@
     <PackageReference Include="Serilog.Expressions" Version="3.3.0" />
     <PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
+    <PackageReference Include="PolySharp" Version="1.13.1" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Serilog.Settings.Configuration/ConfigurationLoggerConfigurationExtensions.cs
+++ b/src/Serilog.Settings.Configuration/ConfigurationLoggerConfigurationExtensions.cs
@@ -228,20 +228,20 @@ public static class ConfigurationLoggerConfigurationExtensions
     static ConfigurationReader GetConfigurationReader(IConfiguration configuration, ConfigurationReaderOptions readerOptions, DependencyContext? dependencyContext)
     {
         var assemblyFinder = dependencyContext == null ? AssemblyFinder.Auto() : AssemblyFinder.ForDependencyContext(dependencyContext);
-        var section = string.IsNullOrWhiteSpace(readerOptions.SectionName) ? configuration : configuration.GetSection(readerOptions.SectionName);
+        var section = string.IsNullOrWhiteSpace(readerOptions.SectionName) ? configuration : configuration.GetSection(readerOptions.SectionName!);
         return new ConfigurationReader(section, assemblyFinder, readerOptions, configuration);
     }
 
     static ConfigurationReader GetConfigurationReader(IConfiguration configuration, ConfigurationReaderOptions readerOptions, ConfigurationAssemblySource source)
     {
         var assemblyFinder = AssemblyFinder.ForSource(source);
-        var section = string.IsNullOrWhiteSpace(readerOptions.SectionName) ? configuration : configuration.GetSection(readerOptions.SectionName);
+        var section = string.IsNullOrWhiteSpace(readerOptions.SectionName) ? configuration : configuration.GetSection(readerOptions.SectionName!);
         return new ConfigurationReader(section, assemblyFinder, readerOptions, configuration);
     }
 
     static ConfigurationReader GetConfigurationReader(IConfiguration configuration, ConfigurationReaderOptions readerOptions, IReadOnlyCollection<Assembly> assemblies)
     {
-        var section = string.IsNullOrWhiteSpace(readerOptions.SectionName) ? configuration : configuration.GetSection(readerOptions.SectionName);
+        var section = string.IsNullOrWhiteSpace(readerOptions.SectionName) ? configuration : configuration.GetSection(readerOptions.SectionName!);
         return new ConfigurationReader(section, assemblies, new ResolutionContext(configuration, readerOptions));
     }
 }

--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -2,9 +2,12 @@
 
   <PropertyGroup>
     <Description>Microsoft.Extensions.Configuration (appsettings.json) support for Serilog.</Description>
-    <VersionPrefix>4.0.0</VersionPrefix>
+    <!-- This must match the major and minor components of the referenced Microsoft.Extensions.Logging package. -->
+    <VersionPrefix>7.0.0</VersionPrefix>
     <Authors>Serilog Contributors</Authors>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <!-- These must match the Dependencies tab in https://www.nuget.org/packages/microsoft.settings.configuration at
+        the target version. -->
+    <TargetFrameworks>net462;netstandard2.0;net6.0;net7.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Settings.Configuration</AssemblyName>
     <PackageTags>serilog;json</PackageTags>
@@ -23,11 +26,14 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="6.0.0" />
-    <PackageReference Include="PolySharp" Version="1.12.1" PrivateAssets="All" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="PolySharp" Version="1.13.1" PrivateAssets="All" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
     <None Include="..\..\assets\icon.png" Pack="true" PackagePath="" Visible="false" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- The versions of all references in this group must match the major and minor components of the package version prefix. -->
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="7.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ObjectArgumentValue.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ObjectArgumentValue.cs
@@ -115,7 +115,7 @@ class ObjectArgumentValue : IConfigurationArgumentValue
 
         var type = typeDirective switch
         {
-            not null => Type.GetType(section.GetValue<string>(typeDirective), throwOnError: false),
+            not null => Type.GetType(section.GetValue<string>(typeDirective)!, throwOnError: false),
             null => parameterType,
         };
 

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
@@ -189,10 +189,10 @@ public class ConfigurationReaderTests
     {
         new object[] { GetConfigRoot(appsettingsJsonLevel: minimumLevelFlatTemplate.Format(LogEventLevel.Error)), LogEventLevel.Error },
         new object[] { GetConfigRoot(appsettingsDevelopmentJsonLevel: minimumLevelFlatTemplate.Format(LogEventLevel.Error)), LogEventLevel.Error },
-        new object[] { GetConfigRoot(envVariables: new Dictionary<string, string>() {{minimumLevelFlatKey, LogEventLevel.Error.ToString()}}), LogEventLevel.Error},
+        new object[] { GetConfigRoot(envVariables: new Dictionary<string, string?> {{minimumLevelFlatKey, LogEventLevel.Error.ToString()}}), LogEventLevel.Error},
         new object[] { GetConfigRoot(
                 appsettingsJsonLevel: minimumLevelFlatTemplate.Format(LogEventLevel.Debug),
-                envVariables: new Dictionary<string, string>() {{minimumLevelFlatKey, LogEventLevel.Error.ToString()}}),
+                envVariables: new Dictionary<string, string?> {{minimumLevelFlatKey, LogEventLevel.Error.ToString()}}),
             LogEventLevel.Error
         }
     };
@@ -214,7 +214,7 @@ public class ConfigurationReaderTests
         new object[] { GetConfigRoot(appsettingsJsonLevel: minimumLevelObjectTemplate.Format(LogEventLevel.Error)), LogEventLevel.Error },
         new object[] { GetConfigRoot(appsettingsJsonLevel: minimumLevelObjectTemplate.Format(LogEventLevel.Error.ToString().ToUpper())), LogEventLevel.Error },
         new object[] { GetConfigRoot(appsettingsDevelopmentJsonLevel: minimumLevelObjectTemplate.Format(LogEventLevel.Error)), LogEventLevel.Error },
-        new object[] { GetConfigRoot(envVariables: new Dictionary<string, string>(){{minimumLevelObjectKey, LogEventLevel.Error.ToString() } }), LogEventLevel.Error },
+        new object[] { GetConfigRoot(envVariables: new Dictionary<string, string?>{{minimumLevelObjectKey, LogEventLevel.Error.ToString() } }), LogEventLevel.Error },
         new object[] { GetConfigRoot(
             appsettingsJsonLevel: minimumLevelObjectTemplate.Format(LogEventLevel.Error),
             appsettingsDevelopmentJsonLevel: minimumLevelObjectTemplate.Format(LogEventLevel.Debug)),
@@ -254,7 +254,7 @@ public class ConfigurationReaderTests
         new object[]
         {
             GetConfigRoot(
-                envVariables: new Dictionary<string, string>()
+                envVariables: new Dictionary<string, string?>()
                 {
                     {minimumLevelObjectKey, LogEventLevel.Error.ToString()},
                     {minimumLevelFlatKey, LogEventLevel.Debug.ToString()}

--- a/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
+++ b/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net48</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);net7.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="Serilog.Expressions" Version="3.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/test/Serilog.Settings.Configuration.Tests/Support/ConfigurationReaderTestHelpers.cs
+++ b/test/Serilog.Settings.Configuration.Tests/Support/ConfigurationReaderTestHelpers.cs
@@ -49,13 +49,13 @@ static class ConfigurationReaderTestHelpers
     public static IConfigurationRoot GetConfigRoot(
         string? appsettingsJsonLevel = null,
         string? appsettingsDevelopmentJsonLevel = null,
-        Dictionary<string, string>? envVariables = null)
+        Dictionary<string, string?>? envVariables = null)
     {
         var configBuilder = new ConfigurationBuilder();
 
         configBuilder.AddJsonString(appsettingsJsonLevel            ?? "{}");
         configBuilder.AddJsonString(appsettingsDevelopmentJsonLevel ?? "{}");
-        configBuilder.Add(new ReloadableConfigurationSource(envVariables ?? new Dictionary<string, string>()));
+        configBuilder.Add(new ReloadableConfigurationSource(envVariables ?? new Dictionary<string, string?>()));
 
         return configBuilder.Build();
     }

--- a/test/Serilog.Settings.Configuration.Tests/Support/Extensions.cs
+++ b/test/Serilog.Settings.Configuration.Tests/Support/Extensions.cs
@@ -4,7 +4,7 @@ namespace Serilog.Settings.Configuration.Tests.Support;
 
 public static class Extensions
 {
-    public static object LiteralValue(this LogEventPropertyValue @this)
+    public static object? LiteralValue(this LogEventPropertyValue @this)
     {
         return ((ScalarValue)@this).Value;
     }

--- a/test/Serilog.Settings.Configuration.Tests/Support/JsonStringConfigSource.cs
+++ b/test/Serilog.Settings.Configuration.Tests/Support/JsonStringConfigSource.cs
@@ -22,7 +22,7 @@ class JsonStringConfigSource : IConfigurationSource
         return new ConfigurationBuilder().Add(new JsonStringConfigSource(json)).Build().GetSection(section);
     }
 
-    public static IDictionary<string, string> LoadData(string json)
+    public static IDictionary<string, string?> LoadData(string json)
     {
         var provider = new JsonStringConfigProvider(json);
         provider.Load();
@@ -38,7 +38,7 @@ class JsonStringConfigSource : IConfigurationSource
             _json = json;
         }
 
-        public new IDictionary<string, string> Data => base.Data;
+        public new IDictionary<string, string?> Data => base.Data;
 
         public override void Load()
         {

--- a/test/Serilog.Settings.Configuration.Tests/Support/ReloadableConfigurationSource.cs
+++ b/test/Serilog.Settings.Configuration.Tests/Support/ReloadableConfigurationSource.cs
@@ -5,9 +5,9 @@ namespace Serilog.Settings.Configuration.Tests.Support;
 class ReloadableConfigurationSource : IConfigurationSource
 {
     readonly ReloadableConfigurationProvider _configProvider;
-    readonly IDictionary<string, string> _source;
+    readonly IDictionary<string, string?> _source;
 
-    public ReloadableConfigurationSource(IDictionary<string, string> source)
+    public ReloadableConfigurationSource(IDictionary<string, string?> source)
     {
         _source = source;
         _configProvider = new ReloadableConfigurationProvider(source);
@@ -21,9 +21,9 @@ class ReloadableConfigurationSource : IConfigurationSource
 
     class ReloadableConfigurationProvider : ConfigurationProvider
     {
-        readonly IDictionary<string, string> _source;
+        readonly IDictionary<string, string?> _source;
 
-        public ReloadableConfigurationProvider(IDictionary<string, string> source)
+        public ReloadableConfigurationProvider(IDictionary<string, string?> source)
         {
             _source = source;
         }


### PR DESCRIPTION
See also: https://github.com/serilog/serilog-extensions-logging/pull/222, https://github.com/serilog/serilog-extensions-hosting/pull/71, https://github.com/serilog/serilog-aspnetcore/pull/325

Unfortunately we've had some maintainability problems given the wide spread of target frameworks and dependencies across the Serilog sub-projects.

My aim's to kick through some RTM versions of all of these packages, pinned to their latest Microsoft.Extensions.* counterparts, ASAP.

I know we have https://github.com/serilog/serilog-settings-configuration/pull/343 open here (I've also held up the works there), my proposal is that we "rip the Band-Aid off" and merge this, then merge the release PR as v7.

Note that targeting v7 of the Microsoft.Extensions.* packages doesn't mean dropping earlier TFMs - the majority of the ME* packages continue supporting net462+, netstandard2.0+, and net6.0+.

On the release of .NET 8, the plan would then be to sim-ship Serilog.Extensions.* and Serilog.Settings.Configuration v8.0 versions that depend on the v8.0 dependencies (and so on, for the foreseeable future).