### PR TITLE
Fix build script

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -1,10 +1,10 @@
-echo "build: Build started"
+Write-Output "build: Build started"
 
 Push-Location $PSScriptRoot
 
 if(Test-Path .\artifacts) {
-	echo "build: Cleaning .\artifacts"
-	Remove-Item .\artifacts -Force -Recurse
+    Write-Output "build: Cleaning .\artifacts"
+    Remove-Item .\artifacts -Force -Recurse
 }
 
 $branch = @{ $true = $env:APPVEYOR_REPO_BRANCH; $false = $(git symbolic-ref --short -q HEAD) }[$env:APPVEYOR_REPO_BRANCH -ne $NULL];
@@ -13,12 +13,12 @@ $suffix = @{ $true = ""; $false = "$($branch.Substring(0, [math]::Min(10,$branch
 $commitHash = $(git rev-parse --short HEAD)
 $buildSuffix = @{ $true = "$($suffix)-$($commitHash)"; $false = "$($branch)-$($commitHash)" }[$suffix -ne ""]
 
-echo "build: Package version suffix is $suffix"
-echo "build: Build version suffix is $buildSuffix"
+Write-Output "build: Package version suffix is $suffix"
+Write-Output "build: Build version suffix is $buildSuffix"
 
 & dotnet build --configuration Release --version-suffix=$buildSuffix /p:ContinuousIntegrationBuild=true
 
-if($LASTEXITCODE -ne 0) { exit 1 }
+if($LASTEXITCODE -ne 0) { throw 'build failed' }
 
 if($suffix) {
     & dotnet pack src\Serilog.Settings.Configuration --configuration Release --no-build --no-restore -o artifacts --version-suffix=$suffix
@@ -26,7 +26,7 @@ if($suffix) {
     & dotnet pack src\Serilog.Settings.Configuration --configuration Release --no-build --no-restore -o artifacts
 }
 
-if($LASTEXITCODE -ne 0) { exit 2 }
+if($LASTEXITCODE -ne 0) { throw 'pack failed' }
 
 Write-Output "build: Testing"
 
@@ -35,4 +35,4 @@ Write-Output "build: Testing"
 # The _reported_ runtime is wrong but the _actual_ used runtime is correct, see https://github.com/microsoft/vstest/issues/2037#issuecomment-720549173
 & dotnet test test\Serilog.Settings.Configuration.Tests\bin\Release\*\Serilog.Settings.Configuration.Tests.dll --parallel
 
-if($LASTEXITCODE -ne 0) { exit 3 }
+if($LASTEXITCODE -ne 0) { throw 'unit tests failed' }


### PR DESCRIPTION
Use `throw` to exit when a `dotnet` command fails so that errors are properly reported on AppVeyor.

See also #372