### PR TITLE
Fix tests on .NET Framework 4.8

### DIFF
--- a/test/TestApp/Program.cs
+++ b/test/TestApp/Program.cs
@@ -22,7 +22,7 @@ SelfLog.Enable(Console.Error);
 
 Thread.CurrentThread.Name = "Main thread";
 
-var configurationValues = new Dictionary<string, string>
+var configurationValues = new Dictionary<string, string?>
 {
     ["Serilog:Enrich:0"] = "WithThreadName",
     ["Serilog:WriteTo:0:Name"] = "Console",

--- a/test/TestApp/TestApp.csproj
+++ b/test/TestApp/TestApp.csproj
@@ -14,14 +14,14 @@
   <ItemGroup Condition="$(Configuration) == 'Debug'">
     <ProjectReference Include="..\..\src\Serilog.Settings.Configuration\Serilog.Settings.Configuration.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="$(Configuration) == 'Release'">
     <PackageReference Include="Serilog.Settings.Configuration" Version="[0.0.0-IntegrationTest.0]" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageReference Include="Costura.Fody" Version="5.7.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
     <PackageReference Include="Serilog.Enrichers.Thread" Version="3.1.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
   </ItemGroup>


### PR DESCRIPTION
Was getting this exception because of assembly version mismatch:
> System.IO.FileLoadException: Could not load file or assembly 'Microsoft.Extensions.Configuration.Abstractions, Version=6.0.0.0, Culture=neutral, PublicKeyToken=adb9793829ddae60' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)