### PR TITLE
Fix tests on .NET Framework 4.8 (really)

### DIFF
--- a/test/Serilog.Settings.Configuration.Tests/Support/TestApp.cs
+++ b/test/Serilog.Settings.Configuration.Tests/Support/TestApp.cs
@@ -93,16 +93,18 @@ public class TestApp : IAsyncLifetime
 
         File.WriteAllText(fodyWeaversXml.FullName, publishMode == PublishMode.SingleFile && IsDesktop ? "<Weavers><Costura/></Weavers>" : "<Weavers/>");
 
-        var publishArgs = new[] {
+        var publishArgsBase = new[] {
             "publish",
             "--no-restore",
             "--configuration", "Release",
             "--output", outputDirectory.FullName,
             $"-p:TargetFramework={TargetFramework}"
         };
+        var autoGenerateBindingRedirects = $"-p:AutoGenerateBindingRedirects={publishMode is PublishMode.Standard}";
         var publishSingleFile = $"-p:PublishSingleFile={publishMode is PublishMode.SingleFile or PublishMode.SelfContained}";
         var selfContained = $"-p:SelfContained={publishMode is PublishMode.SelfContained}";
-        await RunDotnetAsync(_workingDirectory, IsDesktop ? publishArgs : publishArgs.Append(publishSingleFile).Append(selfContained).ToArray());
+        var publishArgs = (IsDesktop ? publishArgsBase.Append(autoGenerateBindingRedirects) : publishArgsBase.Append(publishSingleFile).Append(selfContained)).ToArray();
+        await RunDotnetAsync(_workingDirectory, publishArgs);
 
         var executableFileName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "TestApp.exe" : "TestApp";
         var executableFile = new FileInfo(Path.Combine(outputDirectory.FullName, executableFileName));


### PR DESCRIPTION
Was getting this exception because of assembly version mismatch:
> System.IO.FileLoadException: Could not load file or assembly 'System.Runtime.CompilerServices.Unsafe, Version=4.0.4.1, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a' or one of its dependencies. The located assembly's manifest definition does not match the assembly reference. (Exception from HRESULT: 0x80131040)

Automatically generating binding redirects fixes the issue.