### PR TITLE
Add support for overrides from environment variables

### DIFF
--- a/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
+++ b/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net48</TargetFrameworks>
@@ -19,6 +19,7 @@
   <ItemGroup>
     <PackageReference Include="CliWrap" Version="3.6.0" />
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageReference Include="NuGet.Frameworks" Version="6.5.0" />


### PR DESCRIPTION
One of my colleagues was faced with the problem when trying to set the value of the level override from environment variables. This PR helps to do that. @skomis-mm @nblumhardt I have a suspicion that there is another (simpler) solution and I do not believe that all this time no one has come across this problem. However, fix seems to be obvious and non-breaking affecting only cases when level overrides come from environment variables. Configuration from json files works well - it's safe to use dots there.