### PR TITLE
Restore parallel tests execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -201,4 +201,3 @@ FakesAssemblies/
 project.lock.json
 
 artifacts/
-/test/TestApp-*

--- a/Build.ps1
+++ b/Build.ps1
@@ -30,6 +30,9 @@ if($LASTEXITCODE -ne 0) { throw 'pack failed' }
 
 Write-Output "build: Testing"
 
-& dotnet test test\Serilog.Settings.Configuration.Tests\Serilog.Settings.Configuration.Tests.csproj
+# Dotnet test doesn't run separate TargetFrameworks in parallel: https://github.com/dotnet/sdk/issues/19147
+# Workaround: use `dotnet test` on dlls directly in order to pass the `--parallel` option to vstest.
+# The _reported_ runtime is wrong but the _actual_ used runtime is correct, see https://github.com/microsoft/vstest/issues/2037#issuecomment-720549173
+& dotnet test test\Serilog.Settings.Configuration.Tests\bin\Release\*\Serilog.Settings.Configuration.Tests.dll --parallel
 
 if($LASTEXITCODE -ne 0) { throw 'unit tests failed' }

--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.100"
+    "version": "8.0.100",
+    "allowPrerelease": false,
+    "rollForward": "latestFeature"
   }
 }

--- a/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
+++ b/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net48</TargetFrameworks>
     <TargetFrameworks>$(TargetFrameworks);net6.0;net7.0;net8.0</TargetFrameworks>
+    <DeterministicSourcePaths>false</DeterministicSourcePaths>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This reduces the tests execution time in half. On my machine: 76 seconds when run in parallel vs 144 seconds when run serially.

The fix introduced in 41bc33d4bc7b03c920102ddaba195e96d152fb5f (running `dotnet test` on the csproj rather then on the built dlls) was problematic for two reasons.

1. It rebuilds `Serilog.Settings.Configuration.Tests.csproj` in Debug instead of Release and it's unnecessary since it was previously built.
2. It doesn't run tests in parallel anymore, increasing the total tests execution time.

The _right_ fix was to disable deterministic source paths for the test project with `<DeterministicSourcePaths>false</DeterministicSourcePaths>`. This way, the `[CallerFilePath]` attribute works as expected with absolute paths on the current machine instead of being substituted with `/_/` (which was causing the test failures). This looks like a breaking change that was introduced in the .NET 8 SDK.

Also, I added back allowPrerelease = false and rollForward = latestFeature in the global.json file.