### PR TITLE
Prefer "MinimumLevel:Default" value if "MinimumLevel" value returns empty string

### DIFF
--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -200,12 +200,12 @@ class ConfigurationReader : IConfigurationReader
             {
                 foreach (var provider in _configurationRoot.Providers.Reverse())
                 {
-                    if (provider.TryGet(minimumLevelDirective.Path, out _))
+                    if (provider.TryGet(minimumLevelDirective.Path, out var minValue) && !string.IsNullOrEmpty(minValue))
                     {
                         return _configurationRoot.GetSection(minimumLevelDirective.Path);
                     }
 
-                    if (provider.TryGet(defaultLevelDirective.Path, out _))
+                    if (provider.TryGet(defaultLevelDirective.Path, out var defaultValue) && !string.IsNullOrEmpty(defaultValue))
                     {
                         return _configurationRoot.GetSection(defaultLevelDirective.Path);
                     }

--- a/test/Serilog.Settings.Configuration.Tests/LoggerConfigurationExtensionsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/LoggerConfigurationExtensionsTests.cs
@@ -142,7 +142,7 @@ public class LoggerConfigurationExtensionsTests
 
     [Fact]
     [Trait("BugFix", "https://github.com/serilog/serilog-settings-configuration/issues/332")]
-    public void ReadFromConfigurationThrowsWhenMinimumLevelDefaultSetButMinimumLevelValueIsEmptyString()
+    public void ReadFromConfiguration_ShouldNot_Throw_When_MinimumLevel_Default_Set_But_MinimumLevel_Value_Is_Empty_String()
     {
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>

--- a/test/Serilog.Settings.Configuration.Tests/LoggerConfigurationExtensionsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/LoggerConfigurationExtensionsTests.cs
@@ -139,4 +139,23 @@ public class LoggerConfigurationExtensionsTests
             .CreateLogger();
 
     }
+
+    [Fact]
+    [Trait("BugFix", "https://github.com/serilog/serilog-settings-configuration/issues/332")]
+    public void ReadFromConfigurationThrowsWhenMinimumLevelDefaultSetButMinimumLevelValueIsEmptyString()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Serilog"] = "",
+                ["Serilog:MinimumLevel"] = "",
+                ["Serilog:MinimumLevel:Default"] = "Information",
+
+            })
+            .Build();
+
+        new LoggerConfiguration()
+            .ReadFrom.Configuration(configuration)
+            .CreateLogger();
+    }
 }


### PR DESCRIPTION
Use value from `Serilog:MinimumLevel:Default` if value from `Serilog:MinimumLevel` is an empty string.

Fixes #332 