### PR TITLE
Update Microsoft.Extensions.DependencyModel to 8.0.1

### DIFF
--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -38,6 +38,6 @@
   <ItemGroup>
     <!-- The versions of all references in this group must match the major and minor components of the package version prefix. -->
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This updates the transitive dependency on System.Text.Json to 8.0.4, to pick up the fix for https://github.com/advisories/GHSA-hh2w-p6rv-4g7w

refs #425 