### PR TITLE
Update xunit to 2.9.0

### DIFF
--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -60,7 +60,7 @@ public class ConfigurationSettingsTests
     [Theory]
     [InlineData(null)]
     [InlineData("")]
-    public void CanReadWithoutSerilogSection(string sectionName)
+    public void CanReadWithoutSerilogSection(string? sectionName)
     {
         LogEvent? evt = null;
 

--- a/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
+++ b/test/Serilog.Settings.Configuration.Tests/Serilog.Settings.Configuration.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT'">net48</TargetFrameworks>
@@ -25,7 +25,7 @@
     <PackageReference Include="NuGet.Frameworks" Version="6.7.0" />
     <PackageReference Include="Polly" Version="8.2.0" />
     <PackageReference Include="Serilog.Expressions" Version="4.0.0" />
-    <PackageReference Include="xunit" Version="2.5.3" />
+    <PackageReference Include="xunit" Version="2.9.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
     <PackageReference Include="Shouldly" Version="4.2.1" />
     <PackageReference Include="PublicApiGenerator" Version="11.0.0" />

--- a/test/Serilog.Settings.Configuration.Tests/StringArgumentValueTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/StringArgumentValueTests.cs
@@ -54,7 +54,7 @@ public class StringArgumentValueTests
     // a full-qualified type name should not be considered a static member accessor
     [InlineData("My.NameSpace.Class, MyAssembly, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089",
        null, null)]
-    public void TryParseStaticMemberAccessorReturnsExpectedResults(string input, string? expectedAccessorType, string expectedPropertyName)
+    public void TryParseStaticMemberAccessorReturnsExpectedResults(string? input, string? expectedAccessorType, string? expectedPropertyName)
     {
         var actual = StringArgumentValue.TryParseStaticMemberAccessor(input,
             out var actualAccessorType,


### PR DESCRIPTION
Only effects the tests, but - when looking at #425 my Visual Studio was showing a 'vulnerable package' warning because the old version of xunit has tranisitive dependencies through to old versions of System.Net.Http and System.Text.RegularExpressions that have CVEs, and updating to the current version appears to remove those.