### PR TITLE
Make string to enum conversion case insensitive

### DIFF
--- a/src/Serilog.Settings.Configuration/Settings/Configuration/StringArgumentValue.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/StringArgumentValue.cs
@@ -51,7 +51,7 @@ class StringArgumentValue : IConfigurationArgumentValue
         }
 
         if (toTypeInfo.IsEnum)
-            return Enum.Parse(toType, argumentValue);
+            return Enum.Parse(toType, argumentValue, ignoreCase: true);
 
         var convertor = ExtendedTypeConversions
             .Where(t => t.Key.GetTypeInfo().IsAssignableFrom(toTypeInfo))

--- a/test/Serilog.Settings.Configuration.Tests/StringArgumentValueTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/StringArgumentValueTests.cs
@@ -222,10 +222,12 @@ public class StringArgumentValueTests
         Assert.Contains("\"LevelSwitches\":{\"$mySwitch\":", ex.Message);
     }
 
-    [Fact]
-    public void StringValuesConvertToEnumByName()
+    [Theory]
+    [InlineData("Information")]
+    [InlineData("information")]
+    public void StringValuesConvertToEnumByName(string level)
     {
-        var value = new StringArgumentValue(nameof(LogEventLevel.Information));
+        var value = new StringArgumentValue(level);
 
         var actual = value.ConvertTo(typeof(LogEventLevel), new());
 


### PR DESCRIPTION
All other enum parsing performed in the ConfigurationReader is also case insensitive.

Fixes #431