### PR TITLE
Update Microsoft.Extensions.DependencyModel to 8.0.2

### DIFF
--- a/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
+++ b/src/Serilog.Settings.Configuration/Serilog.Settings.Configuration.csproj
@@ -38,6 +38,6 @@
   <ItemGroup>
     <!-- The versions of all references in this group must match the major and minor components of the package version prefix. -->
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
It's CVE Tuesday again, and Microsoft have released a version 8.0.5 of System.Text.Json to fix https://github.com/advisories/GHSA-8g4q-xg66-9fp4 and an 8.0.2 of Microsoft.Extensions.DependencyModel that updates the System.Text.Json dependency to 8.0.5