### PR TITLE
Support LevelAlias names in configuration parsing

### DIFF
--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -571,7 +571,7 @@ class ConfigurationReader : IConfigurationReader
         return Regex.IsMatch(input, LevelSwitchNameRegex);
     }
 
-    static LogEventLevel ParseLogEventLevel(string value)
+    internal static LogEventLevel ParseLogEventLevel(string value)
     {
         // Try parsing as LevelAlias first (handles "Off", "Minimum", "Maximum")
         if (string.Equals(value, "Off", StringComparison.OrdinalIgnoreCase))

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -572,7 +572,20 @@ class ConfigurationReader : IConfigurationReader
     }
 
     static LogEventLevel ParseLogEventLevel(string value)
-        => Enum.TryParse(value, ignoreCase: true, out LogEventLevel parsedLevel)
-            ? parsedLevel
-            : throw new InvalidOperationException($"The value {value} is not a valid Serilog level.");
+    {
+        // Try parsing as LevelAlias first (handles "Off", "Minimum", "Maximum")
+        if (string.Equals(value, "Off", StringComparison.OrdinalIgnoreCase))
+            return LevelAlias.Off;
+        if (string.Equals(value, "Minimum", StringComparison.OrdinalIgnoreCase))
+            return LevelAlias.Minimum;
+        if (string.Equals(value, "Maximum", StringComparison.OrdinalIgnoreCase))
+            return LevelAlias.Maximum;
+
+        // Try parsing as LogEventLevel enum
+        if (Enum.TryParse(value, ignoreCase: true, out LogEventLevel parsedLevel))
+            return parsedLevel;
+
+        throw new InvalidOperationException($"The value {value} is not a valid Serilog level.");
+    }
+
 }

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
@@ -294,4 +294,39 @@ public class ConfigurationReaderTests
 
         AssertLogEventLevels(loggerConfig, LogEventLevel.Error);
     }
+
+    [Theory]
+    // Standard LogEventLevel enum values
+    [InlineData("Verbose", LogEventLevel.Verbose)]
+    [InlineData("Debug", LogEventLevel.Debug)]
+    [InlineData("Information", LogEventLevel.Information)]
+    [InlineData("Warning", LogEventLevel.Warning)]
+    [InlineData("Error", LogEventLevel.Error)]
+    [InlineData("Fatal", LogEventLevel.Fatal)]
+    // Case insensitivity
+    [InlineData("verbose", LogEventLevel.Verbose)]
+    [InlineData("INFORMATION", LogEventLevel.Information)]
+    [InlineData("warning", LogEventLevel.Warning)]
+    // LevelAlias values
+    [InlineData("Off", LevelAlias.Off)]
+    [InlineData("off", LevelAlias.Off)]
+    [InlineData("OFF", LevelAlias.Off)]
+    [InlineData("Minimum", LevelAlias.Minimum)]
+    [InlineData("minimum", LevelAlias.Minimum)]
+    [InlineData("Maximum", LevelAlias.Maximum)]
+    [InlineData("maximum", LevelAlias.Maximum)]
+    public void ParseLogEventLevelHandlesAllLevelValues(string value, LogEventLevel expected)
+    {
+        var result = ConfigurationReader.ParseLogEventLevel(value);
+        Assert.Equal(expected, result);
+    }
+
+    [Theory]
+    [InlineData("InvalidLevel")]
+    [InlineData("")]
+    [InlineData("None")]
+    public void ParseLogEventLevelThrowsForInvalidValues(string value)
+    {
+        Assert.Throws<InvalidOperationException>(() => ConfigurationReader.ParseLogEventLevel(value));
+    }
 }


### PR DESCRIPTION
Fixes #461
## Summary
Updates [ParseLogEventLevel()](cci:1://file:///c:/Users/moham/Documents/osc/serilog-settings-configuration/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs:573:4-588:5) in [ConfigurationReader.cs](cci:7://file:///c:/Users/moham/Documents/osc/serilog-settings-configuration/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs:0:0-0:0) to accept LevelAlias values (`Off`, [Minimum](cci:1://file:///c:/Users/moham/Documents/osc/serilog-settings-configuration/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs:147:4-218:5), `Maximum`) before attempting to parse as [LogEventLevel](cci:1://file:///c:/Users/moham/Documents/osc/serilog-settings-configuration/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs:573:4-588:5) enum.
This allows users to set `"MinimumLevel": "Off"` in [appsettings.json](cci:7://file:///c:/Users/moham/Documents/osc/TestLogLevelOff/appsettings.json:0:0-0:0) to completely disable logging, which previously failed with:
> `InvalidOperationException: The value Off is not a valid Serilog level.`

## Changes
- Modified [ParseLogEventLevel()](cci:1://file:///c:/Users/moham/Documents/osc/serilog-settings-configuration/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs:573:4-588:5) method to check for LevelAlias names first
- Handles "Off", "Minimum", and "Maximum" (case-insensitive)
- Falls back to enum parsing for standard log levels (Verbose, Debug, Information, etc.)

## Testing
- ✅ All existing tests pass (1191/1191)
- ✅ Manual testing confirmed `"MinimumLevel": "Off"` works from configuration
- ✅ Build successful across all target frameworks

This follows the guidance from @nblumhardt in the issue thread.