### PR TITLE
Load from if path scanned

### DIFF
--- a/src/Serilog.Settings.Configuration/Settings/Configuration/Assemblies/AssemblyFinder.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/Assemblies/AssemblyFinder.cs
@@ -5,7 +5,7 @@ namespace Serilog.Settings.Configuration.Assemblies;
 
 abstract class AssemblyFinder
 {
-    public abstract IReadOnlyList<AssemblyName> FindAssembliesContainingName(string nameToFind);
+    public abstract IReadOnlyList<(AssemblyName, string?)> FindAssembliesContainingName(string nameToFind);
 
     protected static bool IsCaseInsensitiveMatch(string? text, string textToFind)
     {

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/Assemblies/CompositeAssemblyFinder.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/Assemblies/CompositeAssemblyFinder.cs
@@ -11,9 +11,9 @@ class CompositeAssemblyFinder : AssemblyFinder
         _assemblyFinders = assemblyFinders;
     }
 
-    public override IReadOnlyList<AssemblyName> FindAssembliesContainingName(string nameToFind)
+    public override IReadOnlyList<(AssemblyName, string?)> FindAssembliesContainingName(string nameToFind)
     {
-        var assemblyNames = new List<AssemblyName>();
+        var assemblyNames = new List<(AssemblyName, string?)>();
         foreach (var assemblyFinder in _assemblyFinders)
         {
             assemblyNames.AddRange(assemblyFinder.FindAssembliesContainingName(nameToFind));

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/Assemblies/DependencyContextAssemblyFinder.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/Assemblies/DependencyContextAssemblyFinder.cs
@@ -12,16 +12,16 @@ sealed class DependencyContextAssemblyFinder : AssemblyFinder
         _dependencyContext = dependencyContext;
     }
 
-    public override IReadOnlyList<AssemblyName> FindAssembliesContainingName(string nameToFind)
+    public override IReadOnlyList<(AssemblyName, string?)> FindAssembliesContainingName(string nameToFind)
     {
         if (_dependencyContext == null)
-            return Array.Empty<AssemblyName>();
+            return Array.Empty<(AssemblyName, string?)>();
 
         var query = from library in _dependencyContext.RuntimeLibraries
                     where IsReferencingSerilog(library)
                     from assemblyName in library.GetDefaultAssemblyNames(_dependencyContext)
                     where IsCaseInsensitiveMatch(assemblyName.Name, nameToFind)
-                    select assemblyName;
+                    select (assemblyName, (string?)null);
 
         return query.ToList();
 

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/Assemblies/DllScanningAssemblyFinder.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/Assemblies/DllScanningAssemblyFinder.cs
@@ -4,7 +4,7 @@ namespace Serilog.Settings.Configuration.Assemblies;
 
 sealed class DllScanningAssemblyFinder : AssemblyFinder
 {
-    public override IReadOnlyList<AssemblyName> FindAssembliesContainingName(string nameToFind)
+    public override IReadOnlyList<(AssemblyName, string?)> FindAssembliesContainingName(string nameToFind)
     {
         var probeDirs = new List<string>();
 
@@ -46,7 +46,7 @@ sealed class DllScanningAssemblyFinder : AssemblyFinder
                     where IsCaseInsensitiveMatch(assemblyFileName, nameToFind)
                     let assemblyName = TryGetAssemblyNameFrom(outputAssemblyPath)
                     where assemblyName != null
-                    select assemblyName;
+                    select (assemblyName, outputAssemblyPath);
 
         return query.ToList();
 

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -357,7 +357,11 @@ class ConfigurationReader : IConfigurationReader
 
         foreach (var (assemblyName, path) in assemblyFinder.FindAssembliesContainingName("serilog"))
         {
+#if NET5_0_OR_GREATER
             var assumed = path == null ? Assembly.Load(assemblyName) : Assembly.LoadFrom(path);
+#else
+            var assumed = Assembly.Load(assemblyName);
+#endif
             assemblies.Add(assumed);
         }
 

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -355,9 +355,9 @@ class ConfigurationReader : IConfigurationReader
             }
         }
 
-        foreach (var assemblyName in assemblyFinder.FindAssembliesContainingName("serilog"))
+        foreach (var (assemblyName, path) in assemblyFinder.FindAssembliesContainingName("serilog"))
         {
-            var assumed = Assembly.Load(assemblyName);
+            var assumed = path == null ? Assembly.Load(assemblyName) : Assembly.LoadFrom(path);
             assemblies.Add(assumed);
         }
 


### PR DESCRIPTION
This commit makes so that .NET 5 won't break if there is an extra DLL in the directory. `Assembly.Load()` has different behavior in .NET 5 vs in other runtimes.

Fixes #466

I'm open to design discussions, as this seems to be a bit of a hack.