### PR TITLE
Fix: Update ConditionalSink expression syntax in sample app

### DIFF
--- a/sample/Sample/appsettings.json
+++ b/sample/Sample/appsettings.json
@@ -46,7 +46,7 @@
     "WriteTo:ConditionalSink": {
       "Name": "Conditional",
       "Args": {
-        "expression": "@Level in ['Error', 'Fatal']",
+        "expression": "@l in ['Error', 'Fatal']",
         "configureSink": [
           {
             "Name": "File",


### PR DESCRIPTION
### Description
This PR updates the `WriteTo:ConditionalSink` expression in the sample application's `appsettings.json` to use the current CLEF syntax. 

The previous syntax (`@Level`) was outdated and prevented the conditional sink from functioning as intended when users ran the sample. It has been updated to the correct syntax (`@l`) as documented in the updated Serilog.Expressions package.

Fixes #337

### Testing Performed
* Ran the sample application locally using the .NET CLI.
* Verified that the conditional sink successfully catches the `Error` logs and writes them to the `%TEMP%/Logs/serilog-configuration-sample-errors.txt` file.