### PR TITLE
Add WriteTo.FallbackChain and WriteTo.Fallible support in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,8 @@ Some Serilog packages require a reference to a logger configuration object. The 
 },
 ```
 
+The same nested pattern applies to wrapping sinks such as `Conditional` (from _[Serilog.Expressions](https://github.com/serilog/serilog-expressions)_), `FallbackChain`, and `Fallible` — see the [sample `appsettings.json`](sample/Sample/appsettings.json) for working examples.
+
 ### Destructuring
 
 Destructuring means extracting pieces of information from an object and create properties with values; Serilog offers the `@` [structure-capturing operator](https://github.com/serilog/serilog/wiki/Structured-Data#preserving-object-structure). In case there is a need to customize the way log events are serialized (e.g., hide property values or replace them with something else), one can define several destructuring policies, like this:

--- a/sample/Sample/AlwaysFailingSink.cs
+++ b/sample/Sample/AlwaysFailingSink.cs
@@ -1,0 +1,13 @@
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Sample;
+
+public class AlwaysFailingSink : ILogEventSink
+{
+    public void Emit(LogEvent logEvent)
+    {
+        throw new InvalidOperationException(
+            "AlwaysFailingSink always throws so the sample can demonstrate fallback/failure-listener behavior.");
+    }
+}

--- a/sample/Sample/SampleFailureListener.cs
+++ b/sample/Sample/SampleFailureListener.cs
@@ -1,0 +1,22 @@
+using Serilog.Core;
+using Serilog.Debugging;
+using Serilog.Events;
+
+namespace Sample;
+
+public class SampleFailureListener : ILoggingFailureListener
+{
+    public void OnLoggingFailed(
+        object sender,
+        LoggingFailureKind kind,
+        string message,
+        IReadOnlyCollection<LogEvent>? events,
+        Exception? exception)
+    {
+        var exceptionDetail = exception is null
+            ? string.Empty
+            : $" — {exception.GetType().Name}: {exception.Message}";
+        SelfLog.WriteLine(
+            $"[SampleFailureListener] {kind} failure from {sender.GetType().Name}: {message} ({events?.Count ?? 0} events){exceptionDetail}");
+    }
+}

--- a/sample/Sample/appsettings.json
+++ b/sample/Sample/appsettings.json
@@ -63,6 +63,43 @@
         ]
       }
     },
+    "WriteTo:FallbackChain": {
+      "Name": "FallbackChain",
+      "Args": {
+        "configureSink": [
+          {
+            "Name": "Sink",
+            "Args": {
+              "sink": { "type": "Sample.AlwaysFailingSink, Sample" }
+            }
+          }
+        ],
+        "configureFallback": [
+          {
+            "Name": "Console",
+            "Args": {
+              "outputTemplate": "[fallback {Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"
+            }
+          }
+        ]
+      }
+    },
+    "WriteTo:Fallible": {
+      "Name": "Fallible",
+      "Args": {
+        "configureSink": [
+          {
+            "Name": "Sink",
+            "Args": {
+              "sink": { "type": "Sample.AlwaysFailingSink, Sample" }
+            }
+          }
+        ],
+        "failureListener": {
+          "type": "Sample.SampleFailureListener, Sample"
+        }
+      }
+    },
     "Enrich": [
       "FromLogContext",
       "WithThreadId",

--- a/sample/Sample/appsettings.json
+++ b/sample/Sample/appsettings.json
@@ -4,7 +4,7 @@
     "LevelSwitches": { "controlSwitch": "Verbose" },
     "FilterSwitches": { "$filterSwitch": "Application = 'Sample'" },
     "MinimumLevel": {
-      "Default": "Debug",
+      "ControlledBy": "$controlSwitch",
       "Override": {
         "Microsoft": "Warning",
         "MyApp.Something.Tricky": "Verbose"
@@ -37,7 +37,10 @@
             "Name": "File",
             "Args": {
               "path": "%TEMP%/Logs/serilog-configuration-sample.txt",
-              "outputTemplate": "{Timestamp:o} [{Level:u3}] ({Application}/{MachineName}/{ThreadId}/{ThreadName}) {Message}{NewLine}{Exception}"
+              "formatter": {
+                "type": "Serilog.Templates.ExpressionTemplate, Serilog.Expressions",
+                "template": "{@t:o} [{@l:u3}] ({Application}/{MachineName}/{ThreadId}/{ThreadName}) {@m}\n{@x}"
+              }
             }
           }
         ]
@@ -116,6 +119,13 @@
           "expression": "Application = 'Sample'",
           "configureEnricher": [ "WithMachineName" ]
         }
+      },
+      {
+        "Name": "WithComputed",
+        "Args": {
+          "name": "ShortContext",
+          "expression": "coalesce(SourceContext, '<no-context>')"
+        }
       }
     ],
     "Properties": {
@@ -147,12 +157,26 @@
         }
       },
       {
+        "Name": "ByExcluding",
+        "Args": {
+          "expression": "Application = 'OtherApp'"
+        }
+      },
+      {
         "Name": "With",
         "Args": {
           "filter": {
             "type": "Sample.CustomFilter, Sample",
             "levelFilter": "Verbose"
           }
+        }
+      }
+    ],
+    "AuditTo": [
+      {
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "[AUDIT {Timestamp:HH:mm:ss} {Level:u3}] {Message:lj}{NewLine}{Exception}"
         }
       }
     ]

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/SurrogateConfigurationMethods.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/SurrogateConfigurationMethods.cs
@@ -55,6 +55,19 @@ static class SurrogateConfigurationMethods
         LoggingLevelSwitch? levelSwitch = null)
         => loggerSinkConfiguration.Logger(configureLogger, restrictedToMinimumLevel, levelSwitch);
 
+    static LoggerConfiguration FallbackChain(
+        LoggerSinkConfiguration loggerSinkConfiguration,
+        Action<LoggerSinkConfiguration> configureSink,
+        Action<LoggerSinkConfiguration> configureFallback,
+        Action<LoggerSinkConfiguration>[]? configureSubsequentFallbacks = null)
+        => loggerSinkConfiguration.FallbackChain(configureSink, configureFallback, configureSubsequentFallbacks ?? []);
+
+    static LoggerConfiguration Fallible(
+        LoggerSinkConfiguration loggerSinkConfiguration,
+        Action<LoggerSinkConfiguration> configureSink,
+        ILoggingFailureListener failureListener)
+        => loggerSinkConfiguration.Fallible(configureSink, failureListener);
+
     // .AuditTo...
     // ========
     static LoggerConfiguration Sink(

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationSettingsTests.cs
@@ -1575,4 +1575,130 @@ public class ConfigurationSettingsTests
         var switch2 = Assert.Contains("$switch2", switches);
         Assert.Equal("Prop = 2", switch2.Expression);
     }
+
+    [Fact]
+    public void WriteToFallbackChainRoutesFailuresToFallbackSink()
+    {
+        // language=json
+        var json = """
+            {
+                "Serilog": {
+                    "Using": ["TestDummies"],
+                    "WriteTo": [{
+                        "Name": "FallbackChain",
+                        "Args": {
+                            "configureSink": [{
+                                "Name": "Sink",
+                                "Args": {
+                                    "sink": {
+                                        "type": "TestDummies.DummyFailingSink, TestDummies"
+                                    }
+                                }
+                            }],
+                            "configureFallback": [{
+                                "Name": "DummyRollingFile",
+                                "Args": { "pathFormat": "C:\\" }
+                            }]
+                        }
+                    }]
+                }
+            }
+            """;
+
+        var log = ConfigFromJson(json)
+            .CreateLogger();
+
+        DummyFailingSink.Reset();
+        DummyRollingFileSink.Reset();
+
+        log.Write(Some.InformationEvent());
+
+        Assert.Equal(1, DummyFailingSink.EmitAttempts);
+        Assert.Single(DummyRollingFileSink.Emitted);
+    }
+
+    [Fact]
+    public void WriteToFallbackChainSupportsSubsequentFallbacks()
+    {
+        // language=json
+        var json = """
+            {
+                "Serilog": {
+                    "Using": ["TestDummies"],
+                    "WriteTo": [{
+                        "Name": "FallbackChain",
+                        "Args": {
+                            "configureSink": [{
+                                "Name": "Sink",
+                                "Args": {
+                                    "sink": { "type": "TestDummies.DummyFailingSink, TestDummies" }
+                                }
+                            }],
+                            "configureFallback": [{
+                                "Name": "Sink",
+                                "Args": {
+                                    "sink": { "type": "TestDummies.DummyFailingSink, TestDummies" }
+                                }
+                            }],
+                            "configureSubsequentFallbacks": [
+                                [{
+                                    "Name": "DummyRollingFile",
+                                    "Args": { "pathFormat": "C:\\" }
+                                }]
+                            ]
+                        }
+                    }]
+                }
+            }
+            """;
+
+        var log = ConfigFromJson(json)
+            .CreateLogger();
+
+        DummyFailingSink.Reset();
+        DummyRollingFileSink.Reset();
+
+        log.Write(Some.InformationEvent());
+
+        Assert.Equal(2, DummyFailingSink.EmitAttempts);
+        Assert.Single(DummyRollingFileSink.Emitted);
+    }
+
+    [Fact]
+    public void WriteToFallibleReportsFailuresToListener()
+    {
+        // language=json
+        var json = """
+            {
+                "Serilog": {
+                    "Using": ["TestDummies"],
+                    "WriteTo": [{
+                        "Name": "Fallible",
+                        "Args": {
+                            "configureSink": [{
+                                "Name": "Sink",
+                                "Args": {
+                                    "sink": { "type": "TestDummies.DummyFailingSink, TestDummies" }
+                                }
+                            }],
+                            "failureListener": {
+                                "type": "TestDummies.DummyFailureListener, TestDummies"
+                            }
+                        }
+                    }]
+                }
+            }
+            """;
+
+        var log = ConfigFromJson(json)
+            .CreateLogger();
+
+        DummyFailingSink.Reset();
+        DummyFailureListener.Reset();
+
+        log.Write(Some.InformationEvent());
+
+        Assert.Equal(1, DummyFailingSink.EmitAttempts);
+        Assert.Equal(1, DummyFailureListener.FailureCount);
+    }
 }

--- a/test/TestDummies/DummyFailingSink.cs
+++ b/test/TestDummies/DummyFailingSink.cs
@@ -1,0 +1,23 @@
+using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies;
+
+public class DummyFailingSink : ILogEventSink
+{
+    [ThreadStatic]
+    static int _emitAttempts;
+
+    public static int EmitAttempts => _emitAttempts;
+
+    public void Emit(LogEvent logEvent)
+    {
+        _emitAttempts++;
+        throw new InvalidOperationException("DummyFailingSink always fails.");
+    }
+
+    public static void Reset()
+    {
+        _emitAttempts = 0;
+    }
+}

--- a/test/TestDummies/DummyFailureListener.cs
+++ b/test/TestDummies/DummyFailureListener.cs
@@ -1,0 +1,27 @@
+using Serilog.Core;
+using Serilog.Events;
+
+namespace TestDummies;
+
+public class DummyFailureListener : ILoggingFailureListener
+{
+    [ThreadStatic]
+    static int _failureCount;
+
+    public static int FailureCount => _failureCount;
+
+    public void OnLoggingFailed(
+        object sender,
+        LoggingFailureKind kind,
+        string message,
+        IReadOnlyCollection<LogEvent>? events,
+        Exception? exception)
+    {
+        _failureCount++;
+    }
+
+    public static void Reset()
+    {
+        _failureCount = 0;
+    }
+}


### PR DESCRIPTION
Closes #473.

## Summary

- Add `FallbackChain` and `Fallible` surrogates to `SurrogateConfigurationMethods` so the two `LoggerSinkConfiguration` instance methods introduced in Serilog 4.1 can be used from `appsettings.json` / `IConfiguration`.
- Extend the `Sample` project with an `AlwaysFailingSink` plus a `SampleFailureListener` so both sections in the sample `appsettings.json` exercise the fallback path and failure-listener path at runtime.
- Add three configuration-level tests covering: primary → fallback routing, subsequent fallbacks via `params` array, and `Fallible` routing failures to a listener.

## Implementation notes

Both methods are instance methods on `LoggerSinkConfiguration` rather than extension methods, so the extension-method scanner in `ConfigurationReader.FindConfigurationExtensionMethods` doesn't discover them — same as the existing `Sink` / `Logger` surrogates.

`FallbackChain`'s third parameter is `params Action<LoggerSinkConfiguration>[]`. Because `params` does not set `ParameterInfo.HasDefaultValue = true`, it isn't treated as omittable by `HasImplicitValueWhenNotSpecified`, so the surrogate uses `= null` explicitly. Same underlying mechanical issue as #441; that broader fix would let the surrogate drop the `?? []` workaround later.

`LoggerAuditSinkConfiguration` does not expose these methods in Serilog (by design — audit pipelines are meant to fail loudly), so no corresponding `AuditTo` surrogates are added.

## Test plan

- [x] `dotnet build` passes on net462 / netstandard2.0 / net8.0 / net9.0 / net10.0
- [x] Full test suite: 325 tests on net8/net10, 326 on net9, 0 failures
- [x] Coverage on the two new surrogate methods: 100% line, 100% branch (measured with `coverlet.collector` locally)
- [x] Sample runs end-to-end and the fallback/failure-listener paths are visibly exercised (`[fallback ...]` lines in console and `[SampleFailureListener]` lines in `SelfLog`)