### PR TITLE
Support C# 13 params collections (IEnumerable<T>, List<T>)

### DIFF
--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -467,8 +467,7 @@ class ConfigurationReader : IConfigurationReader
                 {
                     // Activator.CreateInstance is unlikely to succeed for collections lacking a parameterless constructor,
                     // or those relying on the [CollectionBuilder] attribute for initialization. 
-                    SelfLog.WriteLine(
-                        $"Unable to create an implicit instance of the params collection type '{paramType}' for parameter '{parameter.Name}' on method '{methodToInvoke.Name}'.\n{ex}");
+                    SelfLog.WriteLine($"Unable to create an implicit instance of the params collection type '{paramType}' for parameter '{parameter.Name}' on method '{methodToInvoke.Name}'.\n{ex}");
                 }
             }
         }

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -463,7 +463,13 @@ class ConfigurationReader : IConfigurationReader
                 {
                     return Activator.CreateInstance(paramType);
                 }
-                catch { }
+                catch(Exception ex)
+                {
+                    // Activator.CreateInstance is unlikely to succeed for collections lacking a parameterless constructor,
+                    // or those relying on the [CollectionBuilder] attribute for initialization. 
+                    SelfLog.WriteLine(
+                        $"Unable to create an implicit instance of the params collection type '{paramType}' for parameter '{parameter.Name}' on method '{methodToInvoke.Name}'. {ex}");
+                }
             }
         }
 

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -467,7 +467,7 @@ class ConfigurationReader : IConfigurationReader
                 {
                     // Activator.CreateInstance is unlikely to succeed for collections lacking a parameterless constructor,
                     // or those relying on the [CollectionBuilder] attribute for initialization. 
-                    SelfLog.WriteLine($"Unable to create an implicit instance of the params collection type '{paramType}' for parameter '{parameter.Name}' on method '{methodToInvoke.Name}'.\n{ex}");
+                    SelfLog.WriteLine($"Unable to create an implicit instance of the params collection type `{paramType}` for parameter `{parameter.Name}` on method `{methodToInvoke.Name}`: {ex}");
                 }
             }
         }

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -468,7 +468,7 @@ class ConfigurationReader : IConfigurationReader
                     // Activator.CreateInstance is unlikely to succeed for collections lacking a parameterless constructor,
                     // or those relying on the [CollectionBuilder] attribute for initialization. 
                     SelfLog.WriteLine(
-                        $"Unable to create an implicit instance of the params collection type '{paramType}' for parameter '{parameter.Name}' on method '{methodToInvoke.Name}'. {ex}");
+                        $"Unable to create an implicit instance of the params collection type '{paramType}' for parameter '{parameter.Name}' on method '{methodToInvoke.Name}'.\n{ex}");
                 }
             }
         }

--- a/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
+++ b/src/Serilog.Settings.Configuration/Settings/Configuration/ConfigurationReader.cs
@@ -404,8 +404,13 @@ class ConfigurationReader : IConfigurationReader
         return paramInfo.HasDefaultValue
            // parameters of type IConfiguration are implicitly populated with provided Configuration
            || paramInfo.ParameterType == typeof(IConfiguration)
-           || paramInfo.IsDefined(typeof(ParamArrayAttribute), false)
-           || paramInfo.CustomAttributes.Any(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.ParamCollectionAttribute");
+           || IsParamCollection(paramInfo);
+    }
+
+    static bool IsParamCollection(ParameterInfo paramInfo)
+    {
+        return paramInfo.IsDefined(typeof(ParamArrayAttribute), false)
+            || paramInfo.CustomAttributes.Any(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.ParamCollectionAttribute");
     }
 
     internal object? GetImplicitValueForNotSpecifiedKey(ParameterInfo parameter, MethodInfo methodToInvoke)
@@ -431,9 +436,35 @@ class ConfigurationReader : IConfigurationReader
                                                           $"This is not supported when only a `IConfigSection` has been provided. (method '{methodToInvoke}')");
         }
 
-        if (parameter.IsDefined(typeof(ParamArrayAttribute), false) && parameter.ParameterType.GetElementType() is { } elementType)
+        if (IsParamCollection(parameter))
         {
-            return Array.CreateInstance(elementType, 0);
+            var paramType = parameter.ParameterType;
+
+            bool isByRefLike = paramType.CustomAttributes.Any(a => a.AttributeType.FullName == "System.Runtime.CompilerServices.IsByRefLikeAttribute");
+            if (isByRefLike)
+            {
+                return parameter.HasDefaultValue ? parameter.DefaultValue : null;
+            }
+
+            if (paramType.GetElementType() is { } elementType)
+            {
+                return Array.CreateInstance(elementType, 0);
+            }
+
+            if (paramType.IsGenericType && paramType.IsInterface)
+            {
+                var genericTypeArg = paramType.GetGenericArguments()[0];
+                return Array.CreateInstance(genericTypeArg, 0);
+            }
+
+            if (paramType.IsGenericType && !paramType.IsAbstract)
+            {
+                try
+                {
+                    return Activator.CreateInstance(paramType);
+                }
+                catch { }
+            }
         }
 
         return parameter.HasDefaultValue ? parameter.DefaultValue : null;

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
@@ -1,9 +1,10 @@
-using System.Reflection;
 using Microsoft.Extensions.Configuration;
 using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Settings.Configuration.Assemblies;
 using Serilog.Settings.Configuration.Tests.Support;
+using System.Reflection;
+using static Serilog.Settings.Configuration.Tests.DummyLoggerConfigurationExtensions;
 using static Serilog.Settings.Configuration.Tests.Support.ConfigurationReaderTestHelpers;
 
 namespace Serilog.Settings.Configuration.Tests;
@@ -409,5 +410,33 @@ public class ConfigurationReaderTests
         var result = reader.GetImplicitValueForNotSpecifiedKey(param, method);
 
         Assert.Null(result);
+    }
+
+    [Fact]
+    public void UnsupportedCollection_LogsToSelfLogAndReturnsNull()
+    {
+        var logs = new List<string>();
+        Serilog.Debugging.SelfLog.Enable(msg => logs.Add(msg));
+
+        try
+        {
+            var reader = new ConfigurationReader(
+                JsonStringConfigSource.LoadSection("{}", "Serilog"),
+                AssemblyFinder.ForSource(ConfigurationAssemblySource.UseLoadedAssemblies),
+                new ConfigurationReaderOptions());
+
+            var method = typeof(BrokenLoggerConfigurationExtensions).GetMethod("DummyBrokenCollection")!;
+            var param = method.GetParameters().Last();
+
+            var result = reader.GetImplicitValueForNotSpecifiedKey(param, method);
+
+            Assert.Null(result);
+            Assert.True(logs.Count > 0, "SelfLog count was 0. The catch block was never entered!");
+            Assert.Contains(logs, l => l.Contains("Unable to create an implicit instance"));
+        }
+        finally
+        {
+            Serilog.Debugging.SelfLog.Disable();
+        }
     }
 }

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
@@ -430,8 +430,7 @@ public class ConfigurationReaderTests
 
             var result = reader.GetImplicitValueForNotSpecifiedKey(param, method);
 
-            Assert.Null(result);
-            Assert.True(logs.Count > 0, "SelfLog count was 0. The catch block was never entered!");
+            Assert.NotEmpty(logs);
             Assert.Contains(logs, l => l.Contains("Unable to create an implicit instance"));
         }
         finally

--- a/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
+++ b/test/Serilog.Settings.Configuration.Tests/ConfigurationReaderTests.cs
@@ -373,8 +373,26 @@ public class ConfigurationReaderTests
         var param = method.GetParameters().Last(); // params IEnumerable<string>
 
         var result = reader.GetImplicitValueForNotSpecifiedKey(param, method);
+        var array = Assert.IsType<string[]>(result);
+        Assert.Empty(array);
+    }
 
-        Assert.Null(result);
+    [Fact]
+    public void ParamsListParameter_ReturnsEmptyList()
+    {
+        var reader = new ConfigurationReader(
+            JsonStringConfigSource.LoadSection("{}", "Serilog"),
+            AssemblyFinder.ForSource(ConfigurationAssemblySource.UseLoadedAssemblies),
+            new ConfigurationReaderOptions());
+
+        // Assuming you have a DummyParamsList method in your TestDummies
+        var method = typeof(DummyLoggerConfigurationExtensions).GetMethod("DummyParamsList")!;
+        var param = method.GetParameters().Last(); // params List<string>
+
+        var result = reader.GetImplicitValueForNotSpecifiedKey(param, method);
+
+        var list = Assert.IsType<List<string>>(result);
+        Assert.Empty(list);
     }
 
     [Fact]

--- a/test/Serilog.Settings.Configuration.Tests/DummyLoggerConfigurationExtensions.cs
+++ b/test/Serilog.Settings.Configuration.Tests/DummyLoggerConfigurationExtensions.cs
@@ -54,3 +54,23 @@ static class DummyLoggerConfigurationExtensions
         return loggerSinkConfiguration.Sink(new DummyParamsSink(values.ToArray()));
     }
 }
+
+public static class BrokenLoggerConfigurationExtensions
+{
+    public static LoggerConfiguration DummyBrokenCollection(
+        this LoggerSinkConfiguration loggerSinkConfiguration,
+        params BrokenCollection<string> list)
+    {
+        return loggerSinkConfiguration.Sink(new DummyParamsSink());
+    }
+}
+
+public class BrokenCollection<T> : List<T>
+{
+    public BrokenCollection()
+    {
+        throw new InvalidOperationException("I am broken by design!");
+    }
+    public BrokenCollection(int capacity) : base(capacity) { }
+}
+

--- a/test/Serilog.Settings.Configuration.Tests/DummyLoggerConfigurationExtensions.cs
+++ b/test/Serilog.Settings.Configuration.Tests/DummyLoggerConfigurationExtensions.cs
@@ -40,6 +40,13 @@ static class DummyLoggerConfigurationExtensions
         return loggerSinkConfiguration.Sink(new DummyParamsSink(values.ToArray()));
     }
 
+    public static LoggerConfiguration DummyParamsList(
+        this LoggerSinkConfiguration loggerSinkConfiguration,
+        params System.Collections.Generic.List<string> list)
+    {
+        return loggerSinkConfiguration.Sink(new DummyParamsSink(list.ToArray()));
+    }
+
     public static LoggerConfiguration DummyParamsSpan(
         this LoggerSinkConfiguration loggerSinkConfiguration,
         params ReadOnlySpan<string> values)


### PR DESCRIPTION
Resolves #476 

Following up on the discussion in the issue, this PR implements support for C# 13 generic `params` collections purely for the ergonomic and aesthetic benefits, while intentionally bypassing `ReadOnlySpan` to avoid reflection complexity.

### Changes Included:
*   **Generic Interfaces:** Intercepts types like `params IEnumerable<T>` and safely satisfies the method contract by returning an empty array.
*   **Concrete Collections:** Intercepts generic classes like `params List<T>` or `HashSet<T>` and uses `Activator.CreateInstance` to generate an empty collection.
*   **Legacy-Safe `ref struct` Evasion:** Added a framework-agnostic check using `IsByRefLikeAttribute` to catch types like `ReadOnlySpan<T>`. This ensures we don't attempt to pass a `ref struct` into the `MethodInfo.Invoke` Reflection pipeline, allowing it to safely fall back to `null` across all supported target frameworks.
*   **Tests:** Updated and added tests to verify the behavior for `IEnumerable`, `List`, and `ReadOnlySpan`.